### PR TITLE
Add responsive neon-style cast landing page (/cast.html)

### DIFF
--- a/cast.html
+++ b/cast.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>IX-Party | CAST MEMBERS</title>
+  <style>
+    :root {
+      --bg:#04021a;
+      --panel:#0d0a2b;
+      --line:#7f48ff;
+      --cyan:#31c8ff;
+      --pink:#ff42d0;
+      --text:#eef1ff;
+      --muted:#bac0e8;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Hiragino Kaku Gothic ProN", "Noto Sans JP", system-ui, sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 15% 20%, rgba(65, 112, 255, 0.26), transparent 40%),
+        radial-gradient(circle at 85% 10%, rgba(255, 59, 235, 0.22), transparent 35%),
+        radial-gradient(circle at 70% 70%, rgba(58, 187, 255, 0.15), transparent 38%),
+        repeating-linear-gradient(90deg, rgba(255,255,255,0.04) 0 1px, transparent 1px 64px),
+        repeating-linear-gradient(0deg, rgba(255,255,255,0.03) 0 1px, transparent 1px 64px),
+        var(--bg);
+      min-height: 100vh;
+    }
+    .container { width: min(1200px, 94vw); margin: 0 auto; }
+
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(8px);
+      background: rgba(4,2,26,0.78);
+      border-bottom: 1px solid rgba(140, 102, 255, 0.35);
+    }
+    .topbar .inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 14px 0;
+    }
+    .brand {
+      font-family: Georgia, serif;
+      font-size: clamp(1.6rem, 3vw, 2.3rem);
+      letter-spacing: .04em;
+      color: #d8e0ff;
+      text-shadow: 0 0 12px rgba(140,102,255,.7);
+      text-decoration: none;
+    }
+    .menu {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .menu a {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: .76rem;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      padding: 8px 10px;
+      border-radius: 8px;
+      border: 1px solid transparent;
+    }
+    .menu a.active {
+      border-color: rgba(180,122,255,.65);
+      color: #fff;
+      background: rgba(152,102,255,.17);
+      box-shadow: inset 0 0 14px rgba(130,94,255,.25), 0 0 14px rgba(130,94,255,.3);
+    }
+    .join-btn {
+      padding: 10px 18px;
+      border-radius: 12px;
+      color: white;
+      text-decoration: none;
+      font-weight: 700;
+      border: 1px solid rgba(255,66,208,.7);
+      background: linear-gradient(90deg, rgba(97,57,255,.35), rgba(255,66,208,.25));
+      box-shadow: 0 0 16px rgba(212,83,255,.45);
+      white-space: nowrap;
+    }
+
+    .hero {
+      padding: clamp(26px, 4vw, 54px) 0 20px;
+      display: grid;
+      grid-template-columns: 1.2fr .9fr;
+      gap: 26px;
+      align-items: center;
+    }
+    .hero h1 {
+      margin: 0;
+      font-family: Georgia, serif;
+      font-size: clamp(2rem, 6vw, 4rem);
+      letter-spacing: .03em;
+      text-shadow: 0 0 20px rgba(202,109,255,.7);
+    }
+    .hero p {
+      color: #d6dbfc;
+      line-height: 1.8;
+      margin: 10px 0 0;
+    }
+    .tags {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(120px, 1fr));
+      gap: 10px;
+    }
+    .tag {
+      padding: 14px 12px;
+      border-radius: 12px;
+      border: 1px solid rgba(118,164,255,.35);
+      background: rgba(18,20,59,.65);
+      text-align: center;
+      font-size: .88rem;
+      color: #c7d1ff;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 14px;
+      padding-bottom: 18px;
+    }
+    .card {
+      position: relative;
+      border-radius: 14px;
+      overflow: hidden;
+      border: 1px solid rgba(144,99,255,.75);
+      background: #09071f;
+      min-height: 300px;
+      box-shadow: 0 0 0 1px rgba(94,175,255,.3), 0 0 24px rgba(112,84,255,.28);
+    }
+    .photo {
+      height: 220px;
+      background-size: cover;
+      background-position: center;
+      filter: saturate(120%);
+    }
+    .p1 { background-image: radial-gradient(circle at 30% 20%, #ffcdaf 0 10%, transparent 28%), linear-gradient(135deg, #0a1b55, #5d1a71 55%, #1ca1ff); }
+    .p2 { background-image: radial-gradient(circle at 70% 12%, #ffd4ba 0 10%, transparent 24%), linear-gradient(135deg, #5a1f64, #ab39d2 40%, #2b3687); }
+    .p3 { background-image: radial-gradient(circle at 65% 16%, #f6d9c9 0 11%, transparent 24%), linear-gradient(135deg, #042b65, #2651ad 50%, #380b60); }
+    .p4 { background-image: radial-gradient(circle at 55% 17%, #ffd7ca 0 10%, transparent 24%), linear-gradient(135deg, #1e123c, #6a2f7b 48%, #d13ea0); }
+    .p5 { background-image: radial-gradient(circle at 40% 12%, #f7d7cb 0 10%, transparent 24%), linear-gradient(135deg, #03233f, #0f4f8f 55%, #22b2de); }
+    .p6 { background-image: radial-gradient(circle at 60% 20%, #f5d7c5 0 9%, transparent 24%), linear-gradient(135deg, #28061a, #7f1138 45%, #ff6634); }
+    .p7 { background-image: radial-gradient(circle at 40% 16%, #f3d8ca 0 9%, transparent 22%), linear-gradient(135deg, #1e1642, #3f4eb2 52%, #88d7ff); }
+    .p8 { background-image: radial-gradient(circle at 62% 13%, #fbd8c8 0 10%, transparent 23%), linear-gradient(135deg, #311650, #5e2092 52%, #ec59c8); }
+    .p9 { background-image: radial-gradient(circle at 52% 15%, #f8d4be 0 10%, transparent 23%), linear-gradient(135deg, #2e1859, #24449f 52%, #2caef2); }
+
+    .meta {
+      padding: 14px;
+      border-top: 1px solid rgba(180,130,255,.35);
+      background: linear-gradient(to top, rgba(6,6,22,.95), rgba(7,9,33,.65));
+    }
+    .num {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      padding: 5px 9px;
+      font-family: Georgia, serif;
+      font-size: 1.6rem;
+      line-height: 1;
+      border-radius: 10px;
+      border: 1px solid rgba(143,216,255,.75);
+      background: rgba(5,21,53,.8);
+      box-shadow: 0 0 16px rgba(84,174,255,.55);
+    }
+    .name { font-size: 2rem; margin: 0; letter-spacing: .04em; font-family: serif; }
+    .role { margin: 4px 0 8px; color: #b9c5ff; font-size: .9rem; }
+    .catch { margin: 0; color: #e5e9ff; font-size: .92rem; }
+
+    .card.wide {
+      grid-column: span 2;
+      display: grid;
+      grid-template-columns: 1.1fr 1.4fr;
+      min-height: 190px;
+    }
+    .card.wide .photo { height: 100%; }
+    .card.wide .meta { border-top: 0; border-left: 1px solid rgba(180,130,255,.35); }
+
+    .footer-cta {
+      display: flex;
+      justify-content: flex-end;
+      padding: 8px 0 32px;
+    }
+    .footer-cta a {
+      display: inline-flex;
+      align-items: center;
+      gap: 14px;
+      padding: 14px 24px;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 14px;
+      border: 1px solid rgba(93,203,255,.9);
+      background: linear-gradient(90deg, rgba(129,53,255,.45), rgba(42,170,255,.35));
+      box-shadow: 0 0 24px rgba(93,203,255,.45), 0 0 24px rgba(192,77,255,.35);
+      font-size: 1.08rem;
+      font-weight: 700;
+    }
+
+    @media (max-width: 1060px) {
+      .grid { grid-template-columns: repeat(2, 1fr); }
+      .hero { grid-template-columns: 1fr; }
+      .footer-cta { justify-content: center; }
+    }
+    @media (max-width: 680px) {
+      .topbar .inner { flex-direction: column; align-items: stretch; }
+      .menu { justify-content: space-between; }
+      .join-btn { text-align: center; }
+      .grid { grid-template-columns: 1fr; }
+      .card.wide { grid-column: auto; grid-template-columns: 1fr; }
+      .card.wide .meta { border-left: 0; border-top: 1px solid rgba(180,130,255,.35); }
+      .tags { grid-template-columns: 1fr 1fr; }
+      .name { font-size: 1.8rem; }
+    }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="container inner">
+      <a class="brand" href="/">IX-Party</a>
+      <nav class="menu">
+        <a href="/">HOME</a>
+        <a href="#">ABOUT</a>
+        <a href="#">ACTIVITY</a>
+        <a class="active" href="/cast.html">CAST</a>
+        <a href="#">EVENT</a>
+        <a href="#">REPORT</a>
+        <a href="#">CONTACT</a>
+      </nav>
+      <a href="#" class="join-btn">コミュニティに参加する</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <div>
+        <h1>CAST MEMBERS</h1>
+        <p>伊万里市のDX勉強会 メンバー紹介。<br>伊万里をもっとスマートに、もっと楽しく。私たちは、学びをエンタメに変えるDX集団。</p>
+      </div>
+      <div class="tags">
+        <div class="tag">AI・データ活用</div>
+        <div class="tag">クラウド活用</div>
+        <div class="tag">つながる学び</div>
+        <div class="tag">地域DX推進</div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card"><div class="num">01</div><div class="photo p1"></div><div class="meta"><h2 class="name">七瀬 リオナ</h2><p class="role">リーダー / 戦略担当</p><p class="catch">ビジョンはデカく、やることはスマートに。</p></div></article>
+      <article class="card"><div class="num">02</div><div class="photo p2"></div><div class="meta"><h2 class="name">天音 サラ</h2><p class="role">データ分析の魔法使い</p><p class="catch">数字は嘘をつかない。でも、私が飾る。</p></div></article>
+      <article class="card"><div class="num">03</div><div class="photo p3"></div><div class="meta"><h2 class="name">神楽 エリカ</h2><p class="role">AI活用エンジェル</p><p class="catch">AIも私にメロメロ。使いこなしてこそDX。</p></div></article>
+      <article class="card"><div class="num">04</div><div class="photo p4"></div><div class="meta"><h2 class="name">桜井 ミライ</h2><p class="role">コミュニティ担当</p><p class="catch">つながりが未来をつくるの。知ってる？</p></div></article>
+      <article class="card"><div class="num">05</div><div class="photo p5"></div><div class="meta"><h2 class="name">白石 ルカ</h2><p class="role">UI/UXデザイナー</p><p class="catch">見た目も使いやすさも、正義でしょ？</p></div></article>
+      <article class="card"><div class="num">06</div><div class="photo p6"></div><div class="meta"><h2 class="name">紅城 レン</h2><p class="role">セキュリティ番長</p><p class="catch">守るからこそ、攻められる。覚えときな。</p></div></article>
+      <article class="card"><div class="num">07</div><div class="photo p7"></div><div class="meta"><h2 class="name">星野 アイ</h2><p class="role">クラウドの女神</p><p class="catch">雲の上は、意外と快適よ。ついてきて。</p></div></article>
+      <article class="card"><div class="num">08</div><div class="photo p8"></div><div class="meta"><h2 class="name">相良 ナナセ</h2><p class="role">DX推進サポーター</p><p class="catch">小さな一歩が、伊万里の未来を変えるの。</p></div></article>
+      <article class="card wide"><div class="num">09</div><div class="photo p9"></div><div class="meta"><h2 class="name">九伊万里鈴</h2><p class="role">バーチャルPR担当</p><p class="catch">伊万里の魅力も、DXの楽しさも、私が届けるよ。</p></div></article>
+    </section>
+
+    <div class="footer-cta">
+      <a href="#">コミュニティに参加する →</a>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Implement a new landing page at `/cast.html` matching the supplied neon/cyber-style design and content layout for cast members. 
- Provide a self-contained, single-file implementation so the page can be dropped into the site without additional assets.
- Ensure the page is responsive so it works on desktop, tablet and mobile breakpoints.

### Description
- Added `cast.html` containing HTML and scoped CSS that implements a sticky header/navigation, hero section, feature tags, a 9-member cast grid of cards, and a bottom CTA. 
- Visual styling uses layered radial/linear gradients, glow/shadow effects and per-card gradient backgrounds to reproduce the neon aesthetic; the wide featured card spans two columns on large screens. 
- Responsive rules convert the grid from 4→2→1 columns at `1060px` and `680px` breakpoints and adjust the hero and wide-card layout for smaller screens. 
- File is committed as a new single-file page so it can be served at `/cast.html` immediately.

### Testing
- Ran HTML validation attempt with `xmllint --html --noout cast.html`, which failed to run because `xmllint` is not available in the environment (tool missing).
- Ran `git status --short` which completed successfully to confirm the working tree state.
- Ran `git rev-parse --short HEAD` which returned the new commit id `8205911` to confirm the commit was created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e10365588325954eafef5c8b5c74)