### PR TITLE
Refactor `bear.html` to improve maintainability and readability

### DIFF
--- a/bear.html
+++ b/bear.html
@@ -1,1 +1,1149 @@
-<!doctype html><html lang=ja><head><meta charset=utf-8><meta name=viewport content=width=device-width,initial-scale=1,viewport-fit=cover><meta name=theme-color content=#f7fbf2><title>Bearクラス 進行タイマー</title><style>:root{--bg:#f7fbf2;--ink:#1d2a25;--muted:#64736c;--line:#d7e7dc;--g:#176c45;--blue:#347fc4}*{box-sizing:border-box}html{background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}body{margin:0;background:linear-gradient(#fbfff6,#eef7fb);min-height:100vh}button{min-height:44px;border:1px solid var(--line);border-radius:8px;background:white;color:var(--ink);font:inherit;font-weight:800;touch-action:manipulation}button:active{transform:translateY(1px)}.app{width:min(100%,390px);margin:auto;min-height:100vh;padding-bottom:78px}header{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:calc(10px + env(safe-area-inset-top)) 12px 8px}.brand{display:flex;align-items:center;gap:10px}.logo{display:grid;place-items:center;width:44px;height:44px;border:2px solid #9a6a3a;border-radius:6px;background:#d9a86e;color:#51351e;font-weight:950}.k{margin:0;color:var(--muted);font-size:12px;font-weight:800}h1{margin:2px 0 0;font-size:16px}.badge{padding:7px 9px;border:1px solid #cfe2d5;border-radius:99px;background:#fff9de;color:#6d5317;font-size:12px;font-weight:900}main{padding:0 10px}.timer{position:sticky;top:0;z-index:5;margin-bottom:8px;padding:10px;border:1px solid var(--line);border-radius:8px;background:#fffffff2;box-shadow:0 10px 24px #23352e1a;backdrop-filter:blur(10px)}.top{display:flex;justify-content:space-between;gap:10px}.clock{display:block;font-size:32px;font-weight:950;font-variant-numeric:tabular-nums;line-height:1}.sec{max-width:45%;align-self:start;padding:8px;border-radius:8px;background:#f0f7f4;color:var(--g);font-size:13px;font-weight:900;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.bar{height:10px;margin:12px 0 8px;border-radius:99px;background:#e6eee9;overflow:hidden}.bar i{display:block;height:100%;width:0;background:linear-gradient(90deg,#2e9961,#ffe27a,#347fc4)}.meta{display:flex;justify-content:space-between;color:var(--muted);font-size:13px;font-weight:800}.controls,.tabs,.quick .qa{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin-top:10px}.primary{background:var(--g);border-color:var(--g);color:white}.tabs{margin:0 0 8px}.tabs button{min-height:40px;color:var(--muted)}.tabs .on{border-color:#2e9961;background:#e7f7ef;color:var(--g)}.view{display:none}.view.on{display:block}.view.list.on{display:grid}.card,.quick,.group,.note,.tools{border:1px solid var(--line);border-radius:8px;background:white;box-shadow:0 6px 18px #23352e0f}.card{padding:12px}.head{display:flex;justify-content:space-between;gap:10px;margin-bottom:10px}.head h2{margin:2px 0 0;font-size:22px}.done.on{border-color:#2e9961;background:#e7f7ef;color:var(--g)}.block{padding:10px;border-radius:8px;background:#fbfdf8;border-left:4px solid #2e9961}.block+ .block{margin-top:10px}.support{background:#f3f8ff;border-left-color:var(--blue)}.hide-support .support{display:none}.bt{margin-bottom:7px;color:var(--muted);font-size:13px;font-weight:900}.block p{margin:0;font-size:16px;font-weight:680;line-height:1.55;overflow-wrap:anywhere}.support p{font-size:15px}.quick{display:grid;grid-template-columns:88px 1fr;gap:8px;align-items:center;margin-top:8px;padding:10px;background:#fffdf0}.qv{display:block;color:#7b5412;font-size:28px;font-weight:950}.list{display:grid;gap:8px}.group{overflow:hidden}.gt{display:flex;justify-content:space-between;gap:8px;padding:10px 11px;background:#eff8f2;color:var(--g);font-weight:950}.row{display:grid;grid-template-columns:68px 1fr 24px;gap:8px;align-items:center;width:100%;min-height:48px;padding:7px 9px;border:0;border-top:1px solid #e8f1eb;border-radius:0;text-align:left}.row.on{background:#fff9dc}.time{color:var(--g);font-weight:950}.copy{font-size:14px;line-height:1.35;overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}.check{color:#2e9961;text-align:center}.note{padding:10px}.note h2{margin:0 0 8px;font-size:16px}.note li{margin-bottom:7px;line-height:1.55}.tools{display:grid;gap:8px;padding:10px}.danger{background:#fff4f4;color:#9f2e2e}.bottom{position:fixed;left:50%;bottom:0;z-index:10;display:grid;grid-template-columns:1fr 72px 1fr;gap:8px;width:min(100%,390px);padding:8px 10px calc(8px + env(safe-area-inset-bottom));border-top:1px solid var(--line);background:#f7fbf2f5;transform:translateX(-50%);backdrop-filter:blur(10px)}.pos{display:grid;place-items:center;color:var(--muted);font-weight:900}@media(max-width:420px){.badge{display:none}.controls{grid-template-columns:1fr 1fr}.quick{grid-template-columns:1fr}}</style></head><body><div class=app><header><div class=brand><div class=logo>B</div><div><p class=k>Bear Class</p><h1>懇親会 進行タイマー</h1></div></div><div class=badge>v10 PDF</div></header><main><section class=timer><div class=top><div><p class=k>経過</p><output id=clock class=clock>0:00:00</output></div><div id=sec class=sec>開始・注意事項</div></div><div class=bar><i id=bar></i></div><div id=meta class=meta></div><div class=controls><button id=start class=primary>▶ 開始</button><button id=now>◎ 現在</button><button id=minus>−1分</button><button id=plus>＋1分</button></div></section><nav class=tabs><button class=on data-v=run>台本</button><button data-v=tl>全体</button><button data-v=notes>メモ</button><button data-v=tools>道具</button></nav><section id=run class='view on'><article class=card><div class=head><div><p id=curSec class=k>開始・注意事項</p><h2 id=curLabel>0:00</h2></div><button id=done class=done>未完了</button></div><div class=block><div class=bt>司会</div><p id=host></p></div><div id=supportBox class='block support'><div class=bt>サポート係</div><p id=support></p></div></article><section class=quick><div><p class=k>クイズ用</p><output id=quick class=qv>--</output></div><div class=qa><button id=q10>10秒</button><button id=q30>30秒</button><button id=qstop>⏸ 停止</button></div></section></section><section id=tl class='view list'></section><section id=notes class='view list'></section><section id=tools class='view tools'><button id=supportBtn>サポート表示 ON</button><button id=wake>画面ON</button><button id=reset class=danger>リセット</button></section></main><footer class=bottom><button id=prev>← 戻る</button><div id=pos class=pos>1 / 39</div><button id=next>次へ →</button></footer></div><script>const TOTAL=3600,KEY='bear-shinkou-timer-v10',SEC=[[`opening`,`開始・注意事項`,`0:00-0:03`,0,180],[`quiz`,`先生クイズ（7分）`,`0:03-0:10`,180,600],[`comments`,`クイズ締め・先生コメント`,`0:10-0:13`,600,780],[`chat`,`歓談・くじ引き・お菓子`,`0:13-0:35`,780,2100],[`game`,`親子ミニゲーム：新聞紙じゃんけん`,`0:35-0:55`,2100,3300],[`closing`,`終わりの挨拶・片付け`,`0:55-1:00`,3300,3600]],DATA=[[`opening-000`,`opening`,`0:00`,0,`「みなさん、遠足おつかれさまでした！本日は懇親会へご参加いただき、ありがとうございます。これから短い時間ですが、先生クイズと親子ゲームをしながら、楽しく交流できればと思います。」`,`不参加者・途中退出者がいればネームカードを回収する。先生方に前へ出てもらい、2mくらい間隔をあけて立ってもらう。`],[`opening-001`,`opening`,`0:01`,60,`「最初にお願いです。ここは公園なので、お子さんが遊具で遊びたくなった場合は出入り自由です。その場合は、保護者の方が付き添いをお願いします。」`,`スタンプカードを子どもたちへ配る。まとめて近くの保護者へ渡し、回してもらう。`],[`opening-002`,`opening`,`0:02`,120,`「事故やケガがないよう、お子さんから目を離さないようにお願いします。あとでお菓子をお渡ししますが、個別のアレルギー対応が難しいため、各ご家庭で確認をお願いします。ゴミはこちらで回収しますので、最後にお持ちください。」`,`3名ほどの保護者にスタンプを渡し、スタンプ係をお願いする。`],[`opening-003`,`opening`,`0:03`,180,`「それでは、最初のイベントとして先生クイズを行います。先生方、よろしくお願いします！」`,`スタンプ係の立ち位置を確認。司会が時間を見ながら進める。遅れに気づいた役員は合図する。`],[`quiz-rule-1`,`quiz`,`0:03`,195,`“Please guess which teacher gave the answer. Move to the teacher you think is correct.”|「今から先生にちなんだクイズを出します。どの先生の答えだと思うか、親子で相談して、正解だと思う先生のところへ移動してください。」`,`子どもが走らないよう、周囲で声かけする。先生方の位置が分かりやすいように誘導する。`],[`quiz-rule-2`,`quiz`,`0:04`,240,`「移動のときは走らず、ゆっくりお願いします。正解した人にはスタンプを押します。たくさん集めてくださいね！」`,`スタンプカードを持っていない子がいないか確認する。`],[`quiz-q1`,`quiz`,`Q1`,260,`【早起き】|“Question 1. Which teacher woke up the earliest this morning?”|「第1問です。今朝、一番早起きだった先生は誰でしょう？」|“You have 10 seconds to move. Ten, nine, eight...”|「10秒数えます。正解だと思う先生のところへ移動してください。10, 9, 8...」`,`子どもたちの移動を見守る。`],[`quiz-q1-answer`,`quiz`,`Q1 正解`,300,`“Let's ask the teachers. Maiko sensei, what time did you wake up? How about Miri sensei? And Nicole sensei?”|「決まりましたか？では先生たちに聞いてみましょう。Maiko先生、何時に起きましたか？ Miri先生は？ Nicole先生は？」|「正解は、〇〇先生でした！」`,`当日確認。正解者にスタンプを押す。`],[`quiz-q2`,`quiz`,`Q2`,325,`【好きな食べ物】|“Question 2. Which teacher's favorite food is chocolate?”|「続いて第2問です。チョコレートが一番好きな食べ物の先生は誰でしょう？」|“You have 10 seconds to move. Ten, nine, eight...”|「正解だと思う先生のところへ移動してください。10, 9, 8...」|「正解は、Maiko先生でした！チョコレート、好きなお友だちも多いかな？」`,`Maiko先生。正解者にスタンプを押す。`],[`quiz-q3`,`quiz`,`Q3`,390,`【苦手なもの】|“Question 3. Which teacher does not like corn and peas?”|「第3問です。コーンとお豆がちょっと苦手な先生は誰でしょう？」|“You have 10 seconds to move. Ten, nine, eight...”|「移動してください。10, 9, 8...」|「正解は、Miri先生でした！コーンとお豆、みんなは好きかな？」`,`Miri先生。役員は残り時間を確認し、遅れそうなら司会へ合図する。正解者にスタンプを押す。`],[`quiz-q4`,`quiz`,`Q4`,455,`【よく言う言葉】|“Question 4. Which teacher often says 'Hip Hip'?”|「第4問です。クラスでよく『Hip Hip』と言っている先生は誰でしょう？」|“You have 10 seconds to move. Ten, nine, eight...”|「正解だと思う先生のところへどうぞ。10, 9, 8...」`,`Nicole先生。子どもたちの移動を見守る。`],[`quiz-q4-answer`,`quiz`,`Q4 正解`,510,`“Nicole sensei, could you say it the way you usually do?”|「正解は、Nicole先生でした！Nicole先生、いつもの感じでお願いします。」|Nicole先生の一言後：「ありがとうございます！」`,`子どもたちが聞けるよう少し静かにする。正解者にスタンプを押す。`],[`comments-010`,`comments`,`0:10`,600,`「先生クイズはここまでです。スタンプはいくつ集まりましたか？カードはあとで使いますので、まだ持っていてくださいね。」`,`スタンプ押しが残っていれば手早く完了する。`],[`comments-011`,`comments`,`0:11`,660,`“Teachers, could you please share one thing parents can do that would be helpful?”|「最後に、先生方から保護者へ『こうしてもらえると嬉しいです』ということを一言ずついただければと思います。」`,`先生が話しやすいように周囲を静かにする。`],[`comments-maiko`,`comments`,`0:11`,685,`Maiko先生へ：「Maiko先生、お願いします。」`,``],[`comments-miri`,`comments`,`0:12`,720,`Miri先生へ：「Miri先生、お願いします。」`,``],[`comments-nicole`,`comments`,`0:12`,745,`Nicole先生へ：「Nicole先生、お願いします。」`,``],[`comments-013`,`comments`,`0:13`,780,`「先生方、ありがとうございました。今年度もどうぞよろしくお願いします。みなさん、先生方に拍手をお願いします！」`,`拍手を誘導。先生が退出しやすいよう動線を空ける。先生が退席する際に、マイクを返却する。`],[`chat-013`,`chat`,`0:13`,790,`「ここからは少し歓談タイムに入ります。レジャーシートをお持ちの方は広げていただき、できるだけ円になるように座りましょう。円が大きくなりすぎる場合は、いくつかのグループに分かれてください。」`,`パパ達に声をかけ、レジャーシートを広げる。円になるよう誘導する。`],[`chat-015`,`chat`,`0:15`,900,`「子どもたちは、スタンプカードを持ってこちらに集まってください。スタンプが多い人から順番にくじ引きをします。」`,`くじ引き箱とお菓子を準備する。スタンプ数ごとに子どもを並べる。`],[`chat-017`,`chat`,`0:17`,1020,`「くじを引いたら、番号のお菓子をもらって、パパ・ママのところへ戻ってください。」`,`くじとお菓子を交換する。終わった子を保護者の元へ戻す。`],[`chat-020`,`chat`,`0:20`,1200,`「保護者の皆さんは、近くの方同士でぜひお話しください。」`,`ゴミ袋とウェットティッシュを分かりやすい場所に置く。`],[`chat-020-035`,`chat`,`0:20-0:35`,1220,`必要に応じて話題を振る：「おうちで英語の宿題はどうしていますか？」「園で好きな遊びを話してくれますか？」「休日のおすすめスポットはありますか？」`,`歓談の様子を見ながら、次の新聞紙じゃんけんの準備を始める。新聞紙を配布しやすい場所にまとめる。`],[`game-035`,`game`,`0:35`,2100,`「それでは、親子ミニゲームを始めます。Bearクラスは新聞紙じゃんけんです。親子で1組になってください。」`,`レジャーシートが邪魔になる場合は一部片付ける。新聞紙を1組1枚ずつ配る。`],[`game-036`,`game`,`0:36`,2160,`「新聞紙を広げて、その上に親子で立ってください。小さいお子さんは、保護者の方と一緒に安全に立ってくださいね。」`,`新聞紙同士の間隔を空ける。転びそうな場所がないか確認する。`],[`game-037`,`game`,`0:37`,2220,`「ルールを説明します。岸本さん（父）とじゃんけんをします。岸本さんに負けた親子は、新聞紙を半分に折ります。勝った人とあいこの人は、そのままです。」`,`岸本さん（父）をじゃんけん役として前へ誘導する。`],[`game-038`,`game`,`0:38`,2280,`「だんだん新聞紙が小さくなります。新聞紙から足が出たり、乗れなくなったら終了です。抱っこはOKですが、無理をしないでください。危ないと思ったら、自分たちでストップしてください。」`,`安全面を見守る。無理な抱っこ・片足立ちがあれば声をかける。`],[`game-039`,`game`,`0:39`,2340,`“We will play rock, paper, scissors with Kishimoto-san. If you lose, fold your newspaper in half. Please be careful and have fun!”`,``],[`game-040`,`game`,`0:40`,2400,`「では練習です。Rock, paper, scissors! じゃんけんぽん！」`,`子どもがルールを理解しているか確認する。`],[`game-041`,`game`,`0:41`,2460,`「本番スタートです。岸本さんに負けた人は新聞紙を半分に折ってください。いきます、Rock, paper, scissors! じゃんけんぽん！」`,`負けた組が折れているかサポートする。`],[`game-042-050`,`game`,`0:42-0:50`,2520,`「まだ乗れていますか？無理はしないでくださいね。次いきます、Rock, paper, scissors! じゃんけんぽん！」を繰り返す。`,`危ない組がないか見る。脱落した組には「こちらで応援しましょう」と誘導する。`],[`game-050`,`game`,`0:50`,3000,`「残っている親子は何組でしょう？あと少しです！」`,`残り人数を数える。上位10組程度を把握する。`],[`game-052`,`game`,`0:52`,3120,`「ここで終了です！最後まで残った親子に拍手！」`,`上位10名に追加スタンプを渡す。10名に満たない場合は、残った子＋希望者じゃんけんで調整する。`],[`game-053`,`game`,`0:53`,3180,`「最後まで残ったお友だちは、スタンプをもらってください。みんな、とても上手でした！」`,`スタンプを押す。新聞紙を回収し、ゴミ袋へ入れる。`],[`closing-055`,`closing`,`0:55`,3300,`「皆さま、お時間となりました。本日は遠足後でお疲れのところ、最後までご参加いただきありがとうございました。」`,`ネームカード回収を始める。`],[`closing-056`,`closing`,`0:56`,3360,`「初めての企画で至らない点もあったかと思いますが、皆さまのご協力のおかげで楽しい時間になりました。ありがとうございます。」`,`ゴミ袋を持って周囲を回る。忘れ物がないか確認する。`],[`closing-057`,`closing`,`0:57`,3420,`「この後は自由解散です。引き続き公園で過ごされる方は、ケガや事故がないようお気をつけください。」`,`ネームカードの不足がないか確認する。`],[`closing-058`,`closing`,`0:58`,3480,`「ゴミはこちらで回収します。ネームカードも役員までご返却ください。」`,`回収漏れがあれば声かけする。`],[`closing-059`,`closing`,`0:59`,3540,`「それでは、本日はありがとうございました。今年度もどうぞよろしくお願いします！」`,`会長へ終了報告。ネームカードとゴミ袋を渡す。`]],NOTES=[[`前提`,[`対象：Bear 3-4歳児クラス。親子で参加。`,`先生クイズは、英語で振ってから日本語で補足する。`,`クイズは7分で区切る。司会が時間を見ながら進め、遅れに役員が気づいた場合は合図する。`,`早起き以外は、Maiko先生・Miri先生・Nicole先生に1問ずつ平等に割り振る。`,`司会：堀田（父） / サポート係：堀田（母）、中渡さん / 歓談以降サポート：岸本さん、中渡さん、松尾さん、堀田（母）`]],[`先生クイズ運用`,[`先生クイズの時間は司会が見ながら進める。遅れに役員が気づいた場合は、7分を目安に合図する。`,`4問すべて終わらなくても、7分になったら区切って先生コメントへ移る。`]],[`先生コメント補足`,[`Maiko先生：お家での様子を教えてもらえると嬉しい。どんなことを楽しい・楽しかったと言っているかなど。`,`Miri先生：オープンでフレンドリーなコミュニケーション、家での小さな変化や様子の共有が助かる。`,`Nicole先生：お家でのお子さんの英語の様子をコミュニケーションノートに書いてもらえると嬉しい。`]],[`当日確認`,[`新聞紙じゃんけんでは、親子の安全を最優先にする。無理な体勢は避けてもらう。`]]],L=[[`elapsed`,`経過`],[`host`,`司会`],[`support`,`サポート係`],[`quiz`,`クイズ用`],[`rem`,`残り`],[`over`,`超過`],[`next`,`次`],[`end`,`終了`],[`stop`,`⏸ 停止`],[`done`,`完了`],[`undone`,`未完了`],[`supportOn`,`サポート表示 ON`],[`supportOff`,`サポート表示 OFF`],[`wake`,`画面ON`],[`wakeActive`,`画面ON中`],[`unsupported`,`非対応`],[`unavailable`,`不可`],[`reset`,`リセット`],[`resetConfirm`,`タイマーと完了チェックをリセットしますか？`]];const LT=Object.fromEntries(L),$=q=>document.querySelector(q),$$=q=>document.querySelectorAll(q),E={body:document.body,clock:$('#clock'),bar:$('#bar'),sec:$('#sec'),meta:$('#meta'),start:$('#start'),now:$('#now'),minus:$('#minus'),plus:$('#plus'),curSec:$('#curSec'),curLabel:$('#curLabel'),host:$('#host'),support:$('#support'),supportBox:$('#supportBox'),done:$('#done'),quick:$('#quick'),tl:$('#tl'),notes:$('#notes'),tools:$('#tools'),supportBtn:$('#supportBtn'),wake:$('#wake'),reset:$('#reset'),prev:$('#prev'),next:$('#next'),pos:$('#pos')};let st=load(),wake=null,qt=null,qr=0;function load(){let d={t:0,run:0,base:0,i:0,follow:1,done:{},view:'run',support:1};try{return Object.assign(d,JSON.parse(localStorage.getItem(KEY)||'{}'))}catch{return d}}function save(){localStorage.setItem(KEY,JSON.stringify(Object.assign({},st,{t:elapsed(),base:st.run?Date.now():0})))}function clamp(v,min,max){return Math.min(max,Math.max(min,Number.isFinite(v)?v:min))}function elapsed(){return st.run?clamp(st.t+Math.floor((Date.now()-st.base)/1000),0,TOTAL):clamp(st.t,0,TOTAL)}function idx(t){let x=0;for(let i=0;i<DATA.length&&DATA[i][3]<=t;i++)x=i;return x}function secById(id){return SEC.find(s=>s[0]===id)||SEC[0]}function secByTime(t){return SEC.find(s=>t>=s[3]&&t<s[4])||SEC[SEC.length-1]}function pad(n){return String(n).padStart(2,'0')}function clock(t){return Math.floor(t/3600)+':'+pad(Math.floor(t%3600/60))+':'+pad(t%60)}function mm(t){t=Math.max(0,Math.floor(t));return Math.floor(t/60)+':'+pad(t%60)}function esc(s){return String(s).replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;')}function fmt(s){return esc(s).split('|').join('<br>')}function show(v){st.view=v;save();render()}function render(){let t=elapsed();if(t>=TOTAL&&st.run){st.t=TOTAL;st.run=0;st.base=0}let i=st.follow?idx(t):clamp(st.i,0,DATA.length-1);st.i=i;let d=DATA[i],s=secById(d[1]),cs=secByTime(t),nx=DATA[i+1],remain=cs[4]-t;E.body.classList.toggle('hide-support',!st.support);E.clock.value=clock(t);E.bar.style.width=Math.min(100,t/TOTAL*100)+'%';E.sec.textContent=cs[1];E.meta.innerHTML='<span>'+cs[2]+' / '+(remain>=0?LT.rem+' '+mm(remain):LT.over+' '+mm(-remain))+'</span><span>'+(nx?LT.next+' '+nx[2]+' '+(nx[3]>=t?mm(nx[3]-t):LT.over+' '+mm(t-nx[3])):LT.end)+'</span>';E.start.textContent=st.run?LT.stop:'▶ 開始';E.curSec.textContent=s[1];E.curLabel.textContent=d[2];E.host.innerHTML=fmt(d[4]);E.support.innerHTML=d[5]?fmt(d[5]):' ';E.supportBox.hidden=!d[5];E.done.textContent=st.done[d[0]]?LT.done:LT.undone;E.done.classList.toggle('on',!!st.done[d[0]]);E.pos.textContent=i+1+' / '+DATA.length;E.prev.disabled=i===0;E.next.disabled=i===DATA.length-1;E.supportBtn.textContent=st.support?LT.supportOn:LT.supportOff;$$('.tabs button').forEach(b=>b.classList.toggle('on',b.dataset.v===st.view));$$('.view').forEach(v=>v.classList.toggle('on',v.id===st.view));$$('.row').forEach(r=>{let n=+r.dataset.i,dd=DATA[n];r.classList.toggle('on',n===i);r.querySelector('.check').textContent=st.done[dd[0]]?'✓':''})}function build(){E.tl.innerHTML=SEC.map(s=>'<section class=group><div class=gt><span>'+esc(s[1])+'</span><span>'+s[2]+'</span></div>'+DATA.map((d,i)=>[d,i]).filter(x=>x[0][1]===s[0]).map(x=>'<button class=row data-i='+x[1]+'><span class=time>'+esc(x[0][2])+'</span><span class=copy>'+esc(x[0][4].split('|')[0])+'</span><span class=check></span></button>').join('')+'</section>').join('');E.notes.innerHTML=NOTES.map(n=>'<article class=note><h2>'+esc(n[0])+'</h2><ul>'+n[1].map(x=>'<li>'+esc(x)+'</li>').join('')+'</ul></article>').join('')}function move(n){st.i=clamp((st.follow?idx(elapsed()):st.i)+n,0,DATA.length-1);st.follow=0;save();render()}function quick(n){clearInterval(qt);qr=n;E.quick.value=qr;qt=setInterval(()=>{qr--;E.quick.value=qr>0?qr:0;if(qr<=0){clearInterval(qt);qt=null;if(navigator.vibrate)navigator.vibrate([120,60,120])}},1000)}E.start.onclick=()=>{st.run=!st.run;st.base=Date.now();st.t=elapsed();save();render()};E.now.onclick=()=>{st.follow=1;st.i=idx(elapsed());save();render()};E.minus.onclick=()=>{st.t=clamp(elapsed()-60,0,TOTAL);st.base=Date.now();save();render()};E.plus.onclick=()=>{st.t=clamp(elapsed()+60,0,TOTAL);st.base=Date.now();save();render()};E.prev.onclick=()=>move(-1);E.next.onclick=()=>move(1);E.done.onclick=()=>{let id=DATA[st.i][0];st.done[id]=!st.done[id];save();render()};$('#q10').onclick=()=>quick(10);$('#q30').onclick=()=>quick(30);$('#qstop').onclick=()=>{clearInterval(qt);qt=null;E.quick.value='--'};E.supportBtn.onclick=()=>{st.support=!st.support;save();render()};E.reset.onclick=()=>{if(confirm(LT.resetConfirm)){localStorage.removeItem(KEY);st=load();render()}};E.wake.onclick=async()=>{if(wake){await wake.release();wake=null;E.wake.textContent=LT.wake;return}if(!navigator.wakeLock){E.wake.textContent=LT.unsupported;return}try{wake=await navigator.wakeLock.request('screen');E.wake.textContent=LT.wakeActive;wake.addEventListener('release',()=>{wake=null;E.wake.textContent=LT.wake})}catch{E.wake.textContent=LT.unavailable}};$$('.tabs button').forEach(b=>b.onclick=()=>show(b.dataset.v));E.tl.onclick=e=>{let b=e.target.closest('.row');if(b){st.i=+b.dataset.i;st.follow=0;st.view='run';save();render();scrollTo({top:0,behavior:'smooth'})}};build();setInterval(()=>{if(st.run){render();save()}},500);render();</script></body></html>
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#f7fbf2" />
+    <title>Bearクラス 進行タイマー</title>
+    <style>
+      :root {
+        --bg: #f7fbf2;
+        --ink: #1d2a25;
+        --muted: #64736c;
+        --line: #d7e7dc;
+        --g: #176c45;
+        --blue: #347fc4;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html {
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          Segoe UI,
+          sans-serif;
+      }
+      body {
+        margin: 0;
+        background: linear-gradient(#fbfff6, #eef7fb);
+        min-height: 100vh;
+      }
+      button {
+        min-height: 44px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: white;
+        color: var(--ink);
+        font: inherit;
+        font-weight: 800;
+        touch-action: manipulation;
+      }
+      button:active {
+        transform: translateY(1px);
+      }
+      .app {
+        width: min(100%, 390px);
+        margin: auto;
+        min-height: 100vh;
+        padding-bottom: 78px;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        padding: calc(10px + env(safe-area-inset-top)) 12px 8px;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .logo {
+        display: grid;
+        place-items: center;
+        width: 44px;
+        height: 44px;
+        border: 2px solid #9a6a3a;
+        border-radius: 6px;
+        background: #d9a86e;
+        color: #51351e;
+        font-weight: 950;
+      }
+      .k {
+        margin: 0;
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 800;
+      }
+      h1 {
+        margin: 2px 0 0;
+        font-size: 16px;
+      }
+      .badge {
+        padding: 7px 9px;
+        border: 1px solid #cfe2d5;
+        border-radius: 99px;
+        background: #fff9de;
+        color: #6d5317;
+        font-size: 12px;
+        font-weight: 900;
+      }
+      main {
+        padding: 0 10px;
+      }
+      .timer {
+        position: sticky;
+        top: 0;
+        z-index: 5;
+        margin-bottom: 8px;
+        padding: 10px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: #fffffff2;
+        box-shadow: 0 10px 24px #23352e1a;
+        backdrop-filter: blur(10px);
+      }
+      .top {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+      }
+      .clock {
+        display: block;
+        font-size: 32px;
+        font-weight: 950;
+        font-variant-numeric: tabular-nums;
+        line-height: 1;
+      }
+      .sec {
+        max-width: 45%;
+        align-self: start;
+        padding: 8px;
+        border-radius: 8px;
+        background: #f0f7f4;
+        color: var(--g);
+        font-size: 13px;
+        font-weight: 900;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .bar {
+        height: 10px;
+        margin: 12px 0 8px;
+        border-radius: 99px;
+        background: #e6eee9;
+        overflow: hidden;
+      }
+      .bar i {
+        display: block;
+        height: 100%;
+        width: 0;
+        background: linear-gradient(90deg, #2e9961, #ffe27a, #347fc4);
+      }
+      .meta {
+        display: flex;
+        justify-content: space-between;
+        color: var(--muted);
+        font-size: 13px;
+        font-weight: 800;
+      }
+      .controls,
+      .tabs,
+      .quick .qa {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 6px;
+        margin-top: 10px;
+      }
+      .primary {
+        background: var(--g);
+        border-color: var(--g);
+        color: white;
+      }
+      .tabs {
+        margin: 0 0 8px;
+      }
+      .tabs button {
+        min-height: 40px;
+        color: var(--muted);
+      }
+      .tabs .on {
+        border-color: #2e9961;
+        background: #e7f7ef;
+        color: var(--g);
+      }
+      .view {
+        display: none;
+      }
+      .view.on {
+        display: block;
+      }
+      .view.list.on {
+        display: grid;
+      }
+      .card,
+      .quick,
+      .group,
+      .note,
+      .tools {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: white;
+        box-shadow: 0 6px 18px #23352e0f;
+      }
+      .card {
+        padding: 12px;
+      }
+      .head {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+        margin-bottom: 10px;
+      }
+      .head h2 {
+        margin: 2px 0 0;
+        font-size: 22px;
+      }
+      .done.on {
+        border-color: #2e9961;
+        background: #e7f7ef;
+        color: var(--g);
+      }
+      .block {
+        padding: 10px;
+        border-radius: 8px;
+        background: #fbfdf8;
+        border-left: 4px solid #2e9961;
+      }
+      .block + .block {
+        margin-top: 10px;
+      }
+      .support {
+        background: #f3f8ff;
+        border-left-color: var(--blue);
+      }
+      .hide-support .support {
+        display: none;
+      }
+      .bt {
+        margin-bottom: 7px;
+        color: var(--muted);
+        font-size: 13px;
+        font-weight: 900;
+      }
+      .block p {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 680;
+        line-height: 1.55;
+        overflow-wrap: anywhere;
+      }
+      .support p {
+        font-size: 15px;
+      }
+      .quick {
+        display: grid;
+        grid-template-columns: 88px 1fr;
+        gap: 8px;
+        align-items: center;
+        margin-top: 8px;
+        padding: 10px;
+        background: #fffdf0;
+      }
+      .qv {
+        display: block;
+        color: #7b5412;
+        font-size: 28px;
+        font-weight: 950;
+      }
+      .list {
+        display: grid;
+        gap: 8px;
+      }
+      .group {
+        overflow: hidden;
+      }
+      .gt {
+        display: flex;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 10px 11px;
+        background: #eff8f2;
+        color: var(--g);
+        font-weight: 950;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 68px 1fr 24px;
+        gap: 8px;
+        align-items: center;
+        width: 100%;
+        min-height: 48px;
+        padding: 7px 9px;
+        border: 0;
+        border-top: 1px solid #e8f1eb;
+        border-radius: 0;
+        text-align: left;
+      }
+      .row.on {
+        background: #fff9dc;
+      }
+      .time {
+        color: var(--g);
+        font-weight: 950;
+      }
+      .copy {
+        font-size: 14px;
+        line-height: 1.35;
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+      }
+      .check {
+        color: #2e9961;
+        text-align: center;
+      }
+      .note {
+        padding: 10px;
+      }
+      .note h2 {
+        margin: 0 0 8px;
+        font-size: 16px;
+      }
+      .note li {
+        margin-bottom: 7px;
+        line-height: 1.55;
+      }
+      .tools {
+        display: grid;
+        gap: 8px;
+        padding: 10px;
+      }
+      .danger {
+        background: #fff4f4;
+        color: #9f2e2e;
+      }
+      .bottom {
+        position: fixed;
+        left: 50%;
+        bottom: 0;
+        z-index: 10;
+        display: grid;
+        grid-template-columns: 1fr 72px 1fr;
+        gap: 8px;
+        width: min(100%, 390px);
+        padding: 8px 10px calc(8px + env(safe-area-inset-bottom));
+        border-top: 1px solid var(--line);
+        background: #f7fbf2f5;
+        transform: translateX(-50%);
+        backdrop-filter: blur(10px);
+      }
+      .pos {
+        display: grid;
+        place-items: center;
+        color: var(--muted);
+        font-weight: 900;
+      }
+      @media (max-width: 420px) {
+        .badge {
+          display: none;
+        }
+        .controls {
+          grid-template-columns: 1fr 1fr;
+        }
+        .quick {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <header>
+        <div class="brand">
+          <div class="logo">B</div>
+          <div>
+            <p class="k">Bear Class</p>
+            <h1>懇親会 進行タイマー</h1>
+          </div>
+        </div>
+        <div class="badge">v10 PDF</div>
+      </header>
+      <main>
+        <section class="timer">
+          <div class="top">
+            <div>
+              <p class="k">経過</p>
+              <output id="clock" class="clock">0:00:00</output>
+            </div>
+            <div id="sec" class="sec">開始・注意事項</div>
+          </div>
+          <div class="bar"><i id="bar"></i></div>
+          <div id="meta" class="meta"></div>
+          <div class="controls">
+            <button id="start" class="primary">▶ 開始</button
+            ><button id="now">◎ 現在</button><button id="minus">−1分</button
+            ><button id="plus">＋1分</button>
+          </div>
+        </section>
+        <nav class="tabs">
+          <button class="on" data-v="run">台本</button
+          ><button data-v="tl">全体</button><button data-v="notes">メモ</button
+          ><button data-v="tools">道具</button>
+        </nav>
+        <section id="run" class="view on">
+          <article class="card">
+            <div class="head">
+              <div>
+                <p id="curSec" class="k">開始・注意事項</p>
+                <h2 id="curLabel">0:00</h2>
+              </div>
+              <button id="done" class="done">未完了</button>
+            </div>
+            <div class="block">
+              <div class="bt">司会</div>
+              <p id="host"></p>
+            </div>
+            <div id="supportBox" class="block support">
+              <div class="bt">サポート係</div>
+              <p id="support"></p>
+            </div>
+          </article>
+          <section class="quick">
+            <div>
+              <p class="k">クイズ用</p>
+              <output id="quick" class="qv">--</output>
+            </div>
+            <div class="qa">
+              <button id="q10">10秒</button><button id="q30">30秒</button
+              ><button id="qstop">⏸ 停止</button>
+            </div>
+          </section>
+        </section>
+        <section id="tl" class="view list"></section>
+        <section id="notes" class="view list"></section>
+        <section id="tools" class="view tools">
+          <button id="supportBtn">サポート表示 ON</button
+          ><button id="wake">画面ON</button
+          ><button id="reset" class="danger">リセット</button>
+        </section>
+      </main>
+      <footer class="bottom">
+        <button id="prev">← 戻る</button>
+        <div id="pos" class="pos">1 / 39</div>
+        <button id="next">次へ →</button>
+      </footer>
+    </div>
+    <script>
+      const TOTAL = 3600,
+        KEY = "bear-shinkou-timer-v10",
+        SEC = [
+          [`opening`, `開始・注意事項`, `0:00-0:03`, 0, 180],
+          [`quiz`, `先生クイズ（7分）`, `0:03-0:10`, 180, 600],
+          [`comments`, `クイズ締め・先生コメント`, `0:10-0:13`, 600, 780],
+          [`chat`, `歓談・くじ引き・お菓子`, `0:13-0:35`, 780, 2100],
+          [`game`, `親子ミニゲーム：新聞紙じゃんけん`, `0:35-0:55`, 2100, 3300],
+          [`closing`, `終わりの挨拶・片付け`, `0:55-1:00`, 3300, 3600],
+        ],
+        DATA = [
+          [
+            `opening-000`,
+            `opening`,
+            `0:00`,
+            0,
+            `「みなさん、遠足おつかれさまでした！本日は懇親会へご参加いただき、ありがとうございます。これから短い時間ですが、先生クイズと親子ゲームをしながら、楽しく交流できればと思います。」`,
+            `不参加者・途中退出者がいればネームカードを回収する。先生方に前へ出てもらい、2mくらい間隔をあけて立ってもらう。`,
+          ],
+          [
+            `opening-001`,
+            `opening`,
+            `0:01`,
+            60,
+            `「最初にお願いです。ここは公園なので、お子さんが遊具で遊びたくなった場合は出入り自由です。その場合は、保護者の方が付き添いをお願いします。」`,
+            `スタンプカードを子どもたちへ配る。まとめて近くの保護者へ渡し、回してもらう。`,
+          ],
+          [
+            `opening-002`,
+            `opening`,
+            `0:02`,
+            120,
+            `「事故やケガがないよう、お子さんから目を離さないようにお願いします。あとでお菓子をお渡ししますが、個別のアレルギー対応が難しいため、各ご家庭で確認をお願いします。ゴミはこちらで回収しますので、最後にお持ちください。」`,
+            `3名ほどの保護者にスタンプを渡し、スタンプ係をお願いする。`,
+          ],
+          [
+            `opening-003`,
+            `opening`,
+            `0:03`,
+            180,
+            `「それでは、最初のイベントとして先生クイズを行います。先生方、よろしくお願いします！」`,
+            `スタンプ係の立ち位置を確認。司会が時間を見ながら進める。遅れに気づいた役員は合図する。`,
+          ],
+          [
+            `quiz-rule-1`,
+            `quiz`,
+            `0:03`,
+            195,
+            `“Please guess which teacher gave the answer. Move to the teacher you think is correct.”|「今から先生にちなんだクイズを出します。どの先生の答えだと思うか、親子で相談して、正解だと思う先生のところへ移動してください。」`,
+            `子どもが走らないよう、周囲で声かけする。先生方の位置が分かりやすいように誘導する。`,
+          ],
+          [
+            `quiz-rule-2`,
+            `quiz`,
+            `0:04`,
+            240,
+            `「移動のときは走らず、ゆっくりお願いします。正解した人にはスタンプを押します。たくさん集めてくださいね！」`,
+            `スタンプカードを持っていない子がいないか確認する。`,
+          ],
+          [
+            `quiz-q1`,
+            `quiz`,
+            `Q1`,
+            260,
+            `【早起き】|“Question 1. Which teacher woke up the earliest this morning?”|「第1問です。今朝、一番早起きだった先生は誰でしょう？」|“You have 10 seconds to move. Ten, nine, eight...”|「10秒数えます。正解だと思う先生のところへ移動してください。10, 9, 8...」`,
+            `子どもたちの移動を見守る。`,
+          ],
+          [
+            `quiz-q1-answer`,
+            `quiz`,
+            `Q1 正解`,
+            300,
+            `“Let's ask the teachers. Maiko sensei, what time did you wake up? How about Miri sensei? And Nicole sensei?”|「決まりましたか？では先生たちに聞いてみましょう。Maiko先生、何時に起きましたか？ Miri先生は？ Nicole先生は？」|「正解は、〇〇先生でした！」`,
+            `当日確認。正解者にスタンプを押す。`,
+          ],
+          [
+            `quiz-q2`,
+            `quiz`,
+            `Q2`,
+            325,
+            `【好きな食べ物】|“Question 2. Which teacher's favorite food is chocolate?”|「続いて第2問です。チョコレートが一番好きな食べ物の先生は誰でしょう？」|“You have 10 seconds to move. Ten, nine, eight...”|「正解だと思う先生のところへ移動してください。10, 9, 8...」|「正解は、Maiko先生でした！チョコレート、好きなお友だちも多いかな？」`,
+            `Maiko先生。正解者にスタンプを押す。`,
+          ],
+          [
+            `quiz-q3`,
+            `quiz`,
+            `Q3`,
+            390,
+            `【苦手なもの】|“Question 3. Which teacher does not like corn and peas?”|「第3問です。コーンとお豆がちょっと苦手な先生は誰でしょう？」|“You have 10 seconds to move. Ten, nine, eight...”|「移動してください。10, 9, 8...」|「正解は、Miri先生でした！コーンとお豆、みんなは好きかな？」`,
+            `Miri先生。役員は残り時間を確認し、遅れそうなら司会へ合図する。正解者にスタンプを押す。`,
+          ],
+          [
+            `quiz-q4`,
+            `quiz`,
+            `Q4`,
+            455,
+            `【よく言う言葉】|“Question 4. Which teacher often says 'Hip Hip'?”|「第4問です。クラスでよく『Hip Hip』と言っている先生は誰でしょう？」|“You have 10 seconds to move. Ten, nine, eight...”|「正解だと思う先生のところへどうぞ。10, 9, 8...」`,
+            `Nicole先生。子どもたちの移動を見守る。`,
+          ],
+          [
+            `quiz-q4-answer`,
+            `quiz`,
+            `Q4 正解`,
+            510,
+            `“Nicole sensei, could you say it the way you usually do?”|「正解は、Nicole先生でした！Nicole先生、いつもの感じでお願いします。」|Nicole先生の一言後：「ありがとうございます！」`,
+            `子どもたちが聞けるよう少し静かにする。正解者にスタンプを押す。`,
+          ],
+          [
+            `comments-010`,
+            `comments`,
+            `0:10`,
+            600,
+            `「先生クイズはここまでです。スタンプはいくつ集まりましたか？カードはあとで使いますので、まだ持っていてくださいね。」`,
+            `スタンプ押しが残っていれば手早く完了する。`,
+          ],
+          [
+            `comments-011`,
+            `comments`,
+            `0:11`,
+            660,
+            `“Teachers, could you please share one thing parents can do that would be helpful?”|「最後に、先生方から保護者へ『こうしてもらえると嬉しいです』ということを一言ずついただければと思います。」`,
+            `先生が話しやすいように周囲を静かにする。`,
+          ],
+          [
+            `comments-maiko`,
+            `comments`,
+            `0:11`,
+            685,
+            `Maiko先生へ：「Maiko先生、お願いします。」`,
+            ``,
+          ],
+          [
+            `comments-miri`,
+            `comments`,
+            `0:12`,
+            720,
+            `Miri先生へ：「Miri先生、お願いします。」`,
+            ``,
+          ],
+          [
+            `comments-nicole`,
+            `comments`,
+            `0:12`,
+            745,
+            `Nicole先生へ：「Nicole先生、お願いします。」`,
+            ``,
+          ],
+          [
+            `comments-013`,
+            `comments`,
+            `0:13`,
+            780,
+            `「先生方、ありがとうございました。今年度もどうぞよろしくお願いします。みなさん、先生方に拍手をお願いします！」`,
+            `拍手を誘導。先生が退出しやすいよう動線を空ける。先生が退席する際に、マイクを返却する。`,
+          ],
+          [
+            `chat-013`,
+            `chat`,
+            `0:13`,
+            790,
+            `「ここからは少し歓談タイムに入ります。レジャーシートをお持ちの方は広げていただき、できるだけ円になるように座りましょう。円が大きくなりすぎる場合は、いくつかのグループに分かれてください。」`,
+            `パパ達に声をかけ、レジャーシートを広げる。円になるよう誘導する。`,
+          ],
+          [
+            `chat-015`,
+            `chat`,
+            `0:15`,
+            900,
+            `「子どもたちは、スタンプカードを持ってこちらに集まってください。スタンプが多い人から順番にくじ引きをします。」`,
+            `くじ引き箱とお菓子を準備する。スタンプ数ごとに子どもを並べる。`,
+          ],
+          [
+            `chat-017`,
+            `chat`,
+            `0:17`,
+            1020,
+            `「くじを引いたら、番号のお菓子をもらって、パパ・ママのところへ戻ってください。」`,
+            `くじとお菓子を交換する。終わった子を保護者の元へ戻す。`,
+          ],
+          [
+            `chat-020`,
+            `chat`,
+            `0:20`,
+            1200,
+            `「保護者の皆さんは、近くの方同士でぜひお話しください。」`,
+            `ゴミ袋とウェットティッシュを分かりやすい場所に置く。`,
+          ],
+          [
+            `chat-020-035`,
+            `chat`,
+            `0:20-0:35`,
+            1220,
+            `必要に応じて話題を振る：「おうちで英語の宿題はどうしていますか？」「園で好きな遊びを話してくれますか？」「休日のおすすめスポットはありますか？」`,
+            `歓談の様子を見ながら、次の新聞紙じゃんけんの準備を始める。新聞紙を配布しやすい場所にまとめる。`,
+          ],
+          [
+            `game-035`,
+            `game`,
+            `0:35`,
+            2100,
+            `「それでは、親子ミニゲームを始めます。Bearクラスは新聞紙じゃんけんです。親子で1組になってください。」`,
+            `レジャーシートが邪魔になる場合は一部片付ける。新聞紙を1組1枚ずつ配る。`,
+          ],
+          [
+            `game-036`,
+            `game`,
+            `0:36`,
+            2160,
+            `「新聞紙を広げて、その上に親子で立ってください。小さいお子さんは、保護者の方と一緒に安全に立ってくださいね。」`,
+            `新聞紙同士の間隔を空ける。転びそうな場所がないか確認する。`,
+          ],
+          [
+            `game-037`,
+            `game`,
+            `0:37`,
+            2220,
+            `「ルールを説明します。岸本さん（父）とじゃんけんをします。岸本さんに負けた親子は、新聞紙を半分に折ります。勝った人とあいこの人は、そのままです。」`,
+            `岸本さん（父）をじゃんけん役として前へ誘導する。`,
+          ],
+          [
+            `game-038`,
+            `game`,
+            `0:38`,
+            2280,
+            `「だんだん新聞紙が小さくなります。新聞紙から足が出たり、乗れなくなったら終了です。抱っこはOKですが、無理をしないでください。危ないと思ったら、自分たちでストップしてください。」`,
+            `安全面を見守る。無理な抱っこ・片足立ちがあれば声をかける。`,
+          ],
+          [
+            `game-039`,
+            `game`,
+            `0:39`,
+            2340,
+            `“We will play rock, paper, scissors with Kishimoto-san. If you lose, fold your newspaper in half. Please be careful and have fun!”`,
+            ``,
+          ],
+          [
+            `game-040`,
+            `game`,
+            `0:40`,
+            2400,
+            `「では練習です。Rock, paper, scissors! じゃんけんぽん！」`,
+            `子どもがルールを理解しているか確認する。`,
+          ],
+          [
+            `game-041`,
+            `game`,
+            `0:41`,
+            2460,
+            `「本番スタートです。岸本さんに負けた人は新聞紙を半分に折ってください。いきます、Rock, paper, scissors! じゃんけんぽん！」`,
+            `負けた組が折れているかサポートする。`,
+          ],
+          [
+            `game-042-050`,
+            `game`,
+            `0:42-0:50`,
+            2520,
+            `「まだ乗れていますか？無理はしないでくださいね。次いきます、Rock, paper, scissors! じゃんけんぽん！」を繰り返す。`,
+            `危ない組がないか見る。脱落した組には「こちらで応援しましょう」と誘導する。`,
+          ],
+          [
+            `game-050`,
+            `game`,
+            `0:50`,
+            3000,
+            `「残っている親子は何組でしょう？あと少しです！」`,
+            `残り人数を数える。上位10組程度を把握する。`,
+          ],
+          [
+            `game-052`,
+            `game`,
+            `0:52`,
+            3120,
+            `「ここで終了です！最後まで残った親子に拍手！」`,
+            `上位10名に追加スタンプを渡す。10名に満たない場合は、残った子＋希望者じゃんけんで調整する。`,
+          ],
+          [
+            `game-053`,
+            `game`,
+            `0:53`,
+            3180,
+            `「最後まで残ったお友だちは、スタンプをもらってください。みんな、とても上手でした！」`,
+            `スタンプを押す。新聞紙を回収し、ゴミ袋へ入れる。`,
+          ],
+          [
+            `closing-055`,
+            `closing`,
+            `0:55`,
+            3300,
+            `「皆さま、お時間となりました。本日は遠足後でお疲れのところ、最後までご参加いただきありがとうございました。」`,
+            `ネームカード回収を始める。`,
+          ],
+          [
+            `closing-056`,
+            `closing`,
+            `0:56`,
+            3360,
+            `「初めての企画で至らない点もあったかと思いますが、皆さまのご協力のおかげで楽しい時間になりました。ありがとうございます。」`,
+            `ゴミ袋を持って周囲を回る。忘れ物がないか確認する。`,
+          ],
+          [
+            `closing-057`,
+            `closing`,
+            `0:57`,
+            3420,
+            `「この後は自由解散です。引き続き公園で過ごされる方は、ケガや事故がないようお気をつけください。」`,
+            `ネームカードの不足がないか確認する。`,
+          ],
+          [
+            `closing-058`,
+            `closing`,
+            `0:58`,
+            3480,
+            `「ゴミはこちらで回収します。ネームカードも役員までご返却ください。」`,
+            `回収漏れがあれば声かけする。`,
+          ],
+          [
+            `closing-059`,
+            `closing`,
+            `0:59`,
+            3540,
+            `「それでは、本日はありがとうございました。今年度もどうぞよろしくお願いします！」`,
+            `会長へ終了報告。ネームカードとゴミ袋を渡す。`,
+          ],
+        ],
+        NOTES = [
+          [
+            `前提`,
+            [
+              `対象：Bear 3-4歳児クラス。親子で参加。`,
+              `先生クイズは、英語で振ってから日本語で補足する。`,
+              `クイズは7分で区切る。司会が時間を見ながら進め、遅れに役員が気づいた場合は合図する。`,
+              `早起き以外は、Maiko先生・Miri先生・Nicole先生に1問ずつ平等に割り振る。`,
+              `司会：堀田（父） / サポート係：堀田（母）、中渡さん / 歓談以降サポート：岸本さん、中渡さん、松尾さん、堀田（母）`,
+            ],
+          ],
+          [
+            `先生クイズ運用`,
+            [
+              `先生クイズの時間は司会が見ながら進める。遅れに役員が気づいた場合は、7分を目安に合図する。`,
+              `4問すべて終わらなくても、7分になったら区切って先生コメントへ移る。`,
+            ],
+          ],
+          [
+            `先生コメント補足`,
+            [
+              `Maiko先生：お家での様子を教えてもらえると嬉しい。どんなことを楽しい・楽しかったと言っているかなど。`,
+              `Miri先生：オープンでフレンドリーなコミュニケーション、家での小さな変化や様子の共有が助かる。`,
+              `Nicole先生：お家でのお子さんの英語の様子をコミュニケーションノートに書いてもらえると嬉しい。`,
+            ],
+          ],
+          [
+            `当日確認`,
+            [
+              `新聞紙じゃんけんでは、親子の安全を最優先にする。無理な体勢は避けてもらう。`,
+            ],
+          ],
+        ],
+        L = [
+          [`elapsed`, `経過`],
+          [`host`, `司会`],
+          [`support`, `サポート係`],
+          [`quiz`, `クイズ用`],
+          [`rem`, `残り`],
+          [`over`, `超過`],
+          [`next`, `次`],
+          [`end`, `終了`],
+          [`stop`, `⏸ 停止`],
+          [`done`, `完了`],
+          [`undone`, `未完了`],
+          [`supportOn`, `サポート表示 ON`],
+          [`supportOff`, `サポート表示 OFF`],
+          [`wake`, `画面ON`],
+          [`wakeActive`, `画面ON中`],
+          [`unsupported`, `非対応`],
+          [`unavailable`, `不可`],
+          [`reset`, `リセット`],
+          [`resetConfirm`, `タイマーと完了チェックをリセットしますか？`],
+        ];
+      const LT = Object.fromEntries(L),
+        $ = (q) => document.querySelector(q),
+        $$ = (q) => document.querySelectorAll(q),
+        E = {
+          body: document.body,
+          clock: $("#clock"),
+          bar: $("#bar"),
+          sec: $("#sec"),
+          meta: $("#meta"),
+          start: $("#start"),
+          now: $("#now"),
+          minus: $("#minus"),
+          plus: $("#plus"),
+          curSec: $("#curSec"),
+          curLabel: $("#curLabel"),
+          host: $("#host"),
+          support: $("#support"),
+          supportBox: $("#supportBox"),
+          done: $("#done"),
+          quick: $("#quick"),
+          tl: $("#tl"),
+          notes: $("#notes"),
+          tools: $("#tools"),
+          supportBtn: $("#supportBtn"),
+          wake: $("#wake"),
+          reset: $("#reset"),
+          prev: $("#prev"),
+          next: $("#next"),
+          pos: $("#pos"),
+        };
+      let st = load(),
+        wake = null,
+        qt = null,
+        qr = 0;
+      function load() {
+        let d = {
+          t: 0,
+          run: 0,
+          base: 0,
+          i: 0,
+          follow: 1,
+          done: {},
+          view: "run",
+          support: 1,
+        };
+        try {
+          return Object.assign(
+            d,
+            JSON.parse(localStorage.getItem(KEY) || "{}"),
+          );
+        } catch {
+          return d;
+        }
+      }
+      function save() {
+        localStorage.setItem(
+          KEY,
+          JSON.stringify(
+            Object.assign({}, st, {
+              t: elapsed(),
+              base: st.run ? Date.now() : 0,
+            }),
+          ),
+        );
+      }
+      function clamp(v, min, max) {
+        return Math.min(max, Math.max(min, Number.isFinite(v) ? v : min));
+      }
+      function elapsed() {
+        return st.run
+          ? clamp(st.t + Math.floor((Date.now() - st.base) / 1000), 0, TOTAL)
+          : clamp(st.t, 0, TOTAL);
+      }
+      function idx(t) {
+        let x = 0;
+        for (let i = 0; i < DATA.length && DATA[i][3] <= t; i++) x = i;
+        return x;
+      }
+      function secById(id) {
+        return SEC.find((s) => s[0] === id) || SEC[0];
+      }
+      function secByTime(t) {
+        return SEC.find((s) => t >= s[3] && t < s[4]) || SEC[SEC.length - 1];
+      }
+      function pad(n) {
+        return String(n).padStart(2, "0");
+      }
+      function clock(t) {
+        return (
+          Math.floor(t / 3600) +
+          ":" +
+          pad(Math.floor((t % 3600) / 60)) +
+          ":" +
+          pad(t % 60)
+        );
+      }
+      function mm(t) {
+        t = Math.max(0, Math.floor(t));
+        return Math.floor(t / 60) + ":" + pad(t % 60);
+      }
+      function esc(s) {
+        return String(s)
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;");
+      }
+      function fmt(s) {
+        return esc(s).split("|").join("<br>");
+      }
+      function show(v) {
+        st.view = v;
+        save();
+        render();
+      }
+      function render() {
+        let t = elapsed();
+        if (t >= TOTAL && st.run) {
+          st.t = TOTAL;
+          st.run = 0;
+          st.base = 0;
+        }
+        let i = st.follow ? idx(t) : clamp(st.i, 0, DATA.length - 1);
+        st.i = i;
+        let d = DATA[i],
+          s = secById(d[1]),
+          cs = secByTime(t),
+          nx = DATA[i + 1],
+          remain = cs[4] - t;
+        E.body.classList.toggle("hide-support", !st.support);
+        E.clock.value = clock(t);
+        E.bar.style.width = Math.min(100, (t / TOTAL) * 100) + "%";
+        E.sec.textContent = cs[1];
+        E.meta.innerHTML =
+          "<span>" +
+          cs[2] +
+          " / " +
+          (remain >= 0
+            ? LT.rem + " " + mm(remain)
+            : LT.over + " " + mm(-remain)) +
+          "</span><span>" +
+          (nx
+            ? LT.next +
+              " " +
+              nx[2] +
+              " " +
+              (nx[3] >= t ? mm(nx[3] - t) : LT.over + " " + mm(t - nx[3]))
+            : LT.end) +
+          "</span>";
+        E.start.textContent = st.run ? LT.stop : "▶ 開始";
+        E.curSec.textContent = s[1];
+        E.curLabel.textContent = d[2];
+        E.host.innerHTML = fmt(d[4]);
+        E.support.innerHTML = d[5] ? fmt(d[5]) : " ";
+        E.supportBox.hidden = !d[5];
+        E.done.textContent = st.done[d[0]] ? LT.done : LT.undone;
+        E.done.classList.toggle("on", !!st.done[d[0]]);
+        E.pos.textContent = i + 1 + " / " + DATA.length;
+        E.prev.disabled = i === 0;
+        E.next.disabled = i === DATA.length - 1;
+        E.supportBtn.textContent = st.support ? LT.supportOn : LT.supportOff;
+        $$(".tabs button").forEach((b) =>
+          b.classList.toggle("on", b.dataset.v === st.view),
+        );
+        $$(".view").forEach((v) => v.classList.toggle("on", v.id === st.view));
+        $$(".row").forEach((r) => {
+          let n = +r.dataset.i,
+            dd = DATA[n];
+          r.classList.toggle("on", n === i);
+          r.querySelector(".check").textContent = st.done[dd[0]] ? "✓" : "";
+        });
+      }
+      function build() {
+        E.tl.innerHTML = SEC.map(
+          (s) =>
+            "<section class=group><div class=gt><span>" +
+            esc(s[1]) +
+            "</span><span>" +
+            s[2] +
+            "</span></div>" +
+            DATA.map((d, i) => [d, i])
+              .filter((x) => x[0][1] === s[0])
+              .map(
+                (x) =>
+                  "<button class=row data-i=" +
+                  x[1] +
+                  "><span class=time>" +
+                  esc(x[0][2]) +
+                  "</span><span class=copy>" +
+                  esc(x[0][4].split("|")[0]) +
+                  "</span><span class=check></span></button>",
+              )
+              .join("") +
+            "</section>",
+        ).join("");
+        E.notes.innerHTML = NOTES.map(
+          (n) =>
+            "<article class=note><h2>" +
+            esc(n[0]) +
+            "</h2><ul>" +
+            n[1].map((x) => "<li>" + esc(x) + "</li>").join("") +
+            "</ul></article>",
+        ).join("");
+      }
+      function move(n) {
+        st.i = clamp(
+          (st.follow ? idx(elapsed()) : st.i) + n,
+          0,
+          DATA.length - 1,
+        );
+        st.follow = 0;
+        save();
+        render();
+      }
+      function quick(n) {
+        clearInterval(qt);
+        qr = n;
+        E.quick.value = qr;
+        qt = setInterval(() => {
+          qr--;
+          E.quick.value = qr > 0 ? qr : 0;
+          if (qr <= 0) {
+            clearInterval(qt);
+            qt = null;
+            if (navigator.vibrate) navigator.vibrate([120, 60, 120]);
+          }
+        }, 1000);
+      }
+      E.start.onclick = () => {
+        st.run = !st.run;
+        st.base = Date.now();
+        st.t = elapsed();
+        save();
+        render();
+      };
+      E.now.onclick = () => {
+        st.follow = 1;
+        st.i = idx(elapsed());
+        save();
+        render();
+      };
+      E.minus.onclick = () => {
+        st.t = clamp(elapsed() - 60, 0, TOTAL);
+        st.base = Date.now();
+        save();
+        render();
+      };
+      E.plus.onclick = () => {
+        st.t = clamp(elapsed() + 60, 0, TOTAL);
+        st.base = Date.now();
+        save();
+        render();
+      };
+      E.prev.onclick = () => move(-1);
+      E.next.onclick = () => move(1);
+      E.done.onclick = () => {
+        let id = DATA[st.i][0];
+        st.done[id] = !st.done[id];
+        save();
+        render();
+      };
+      $("#q10").onclick = () => quick(10);
+      $("#q30").onclick = () => quick(30);
+      $("#qstop").onclick = () => {
+        clearInterval(qt);
+        qt = null;
+        E.quick.value = "--";
+      };
+      E.supportBtn.onclick = () => {
+        st.support = !st.support;
+        save();
+        render();
+      };
+      E.reset.onclick = () => {
+        if (confirm(LT.resetConfirm)) {
+          localStorage.removeItem(KEY);
+          st = load();
+          render();
+        }
+      };
+      E.wake.onclick = async () => {
+        if (wake) {
+          await wake.release();
+          wake = null;
+          E.wake.textContent = LT.wake;
+          return;
+        }
+        if (!navigator.wakeLock) {
+          E.wake.textContent = LT.unsupported;
+          return;
+        }
+        try {
+          wake = await navigator.wakeLock.request("screen");
+          E.wake.textContent = LT.wakeActive;
+          wake.addEventListener("release", () => {
+            wake = null;
+            E.wake.textContent = LT.wake;
+          });
+        } catch {
+          E.wake.textContent = LT.unavailable;
+        }
+      };
+      $$(".tabs button").forEach((b) => (b.onclick = () => show(b.dataset.v)));
+      E.tl.onclick = (e) => {
+        let b = e.target.closest(".row");
+        if (b) {
+          st.i = +b.dataset.i;
+          st.follow = 0;
+          st.view = "run";
+          save();
+          render();
+          scrollTo({ top: 0, behavior: "smooth" });
+        }
+      };
+      build();
+      setInterval(() => {
+        if (st.run) {
+          render();
+          save();
+        }
+      }, 500);
+      render();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- `bear.html` was a single-line (one-liner) file which made reading, reviewing and maintaining the HTML/CSS/JS difficult. 
- The `viewport` meta and inline blocks needed normalization so future edits are less error-prone. 
- The intent is purely readability and maintainability while keeping runtime behavior unchanged.

### Description
- Reformatted `bear.html` into a multi-line, properly indented structure separating HTML, CSS and JS so blocks are easier to inspect and edit. 
- Normalized the `meta viewport` tag to a valid, readable form (`width=device-width,initial-scale=1,viewport-fit=cover`). 
- Applied automatic formatting with `prettier` and a small scripted replacement to fix the malformed meta line, preserving all data arrays and script logic. 
- No functional changes to the timer logic, UI text, or data content were introduced.

### Testing
- Ran `npx --yes prettier --write bear.html` and the formatter completed successfully. 
- Verified the file contains newlines and measured line lengths using `wc -l` and a short Python check which reported `has_newlines: True` and `max_line_len: 243`. 
- Verified tool availability with `node -v` and `npx --yes prettier --version`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf6ad46d48325aad052a07dee2a7d)