### PR TITLE
Make timer controls compact and fix tab visibility in bear.css

### DIFF
--- a/bear.css
+++ b/bear.css
@@ -145,13 +145,24 @@
         font-size: 13px;
         font-weight: 800;
       }
-      .controls,
       .tabs,
       .quick .qa {
         display: grid;
         grid-template-columns: repeat(4, 1fr);
         gap: 6px;
         margin-top: 10px;
+      }
+      .controls {
+        display: flex;
+        gap: 6px;
+        margin-top: 10px;
+      }
+      .controls button {
+        flex: 1;
+        min-height: 38px;
+        padding: 0 4px;
+        font-size: 14px;
+        white-space: nowrap;
       }
       .primary {
         background: var(--g);
@@ -255,7 +266,6 @@
         font-weight: 950;
       }
       .list {
-        display: grid;
         gap: 8px;
       }
       .group {


### PR DESCRIPTION
### Motivation
- The timer control buttons under the clock were too large and wrapped to multiple lines, so they need a compact layout to stay on a single row.
- The `全体` list was appearing under the `台本` view because `.list` forced `display: grid` even when the view should be hidden via `.view { display: none }`.

### Description
- Replace the `.controls` grid with a compact flex row and add `.controls button` rules using `flex: 1`, reduced `min-height`, smaller `font-size`, padding, and `white-space: nowrap` to keep four buttons on one line.
- Remove the always-on `display: grid` from `.list` so the existing `.view` / `.view.on` visibility rules control which tab contents are shown.
- Changes are CSS-only and confined to `bear.css` used by `bear.html`.

### Testing
- Ran `git diff --check` to validate there are no whitespace/format issues and it passed.
- Verified repository status with `git status --short` to confirm `bear.css` was the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfd017b208325aafb23412db6b2aa)