### PR TITLE
Simplify Bear timer controls and streamline run screen

### DIFF
--- a/bear.css
+++ b/bear.css
@@ -1,367 +1,312 @@
-      :root {
-        --bg: #f7fbf2;
-        --ink: #1d2a25;
-        --muted: #64736c;
-        --line: #d7e7dc;
-        --g: #176c45;
-        --blue: #347fc4;
-      }
-      * {
-        box-sizing: border-box;
-      }
-      html {
-        background: var(--bg);
-        color: var(--ink);
-        font-family:
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          Segoe UI,
-          sans-serif;
-      }
-      body {
-        margin: 0;
-        background: linear-gradient(#fbfff6, #eef7fb);
-        min-height: 100vh;
-      }
-      button {
-        min-height: 44px;
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: white;
-        color: var(--ink);
-        font: inherit;
-        font-weight: 800;
-        touch-action: manipulation;
-      }
-      button:active {
-        transform: translateY(1px);
-      }
-      .app {
-        width: min(100%, 390px);
-        margin: auto;
-        min-height: 100vh;
-        padding-bottom: 78px;
-      }
-      header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 10px;
-        padding: calc(10px + env(safe-area-inset-top)) 12px 8px;
-      }
-      .brand {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-      }
-      .logo {
-        display: grid;
-        place-items: center;
-        width: 44px;
-        height: 44px;
-        border: 2px solid #9a6a3a;
-        border-radius: 6px;
-        background: #d9a86e;
-        color: #51351e;
-        font-weight: 950;
-      }
-      .k {
-        margin: 0;
-        color: var(--muted);
-        font-size: 12px;
-        font-weight: 800;
-      }
-      h1 {
-        margin: 2px 0 0;
-        font-size: 16px;
-      }
-      .badge {
-        padding: 7px 9px;
-        border: 1px solid #cfe2d5;
-        border-radius: 99px;
-        background: #fff9de;
-        color: #6d5317;
-        font-size: 12px;
-        font-weight: 900;
-      }
-      main {
-        padding: 0 10px;
-      }
-      .timer {
-        position: sticky;
-        top: 0;
-        z-index: 5;
-        margin-bottom: 8px;
-        padding: 10px;
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: #fffffff2;
-        box-shadow: 0 10px 24px #23352e1a;
-        backdrop-filter: blur(10px);
-      }
-      .top {
-        display: flex;
-        justify-content: space-between;
-        gap: 10px;
-      }
-      .clock {
-        display: block;
-        font-size: 32px;
-        font-weight: 950;
-        font-variant-numeric: tabular-nums;
-        line-height: 1;
-      }
-      .sec {
-        max-width: 45%;
-        align-self: start;
-        padding: 8px;
-        border-radius: 8px;
-        background: #f0f7f4;
-        color: var(--g);
-        font-size: 13px;
-        font-weight: 900;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      .bar {
-        height: 10px;
-        margin: 12px 0 8px;
-        border-radius: 99px;
-        background: #e6eee9;
-        overflow: hidden;
-      }
-      .bar i {
-        display: block;
-        height: 100%;
-        width: 0;
-        background: linear-gradient(90deg, #2e9961, #ffe27a, #347fc4);
-      }
-      .meta {
-        display: flex;
-        justify-content: space-between;
-        color: var(--muted);
-        font-size: 13px;
-        font-weight: 800;
-      }
-      .tabs,
-      .quick .qa {
-        display: grid;
-        grid-template-columns: repeat(4, 1fr);
-        gap: 6px;
-        margin-top: 10px;
-      }
-      .controls {
-        display: flex;
-        gap: 6px;
-        margin-top: 10px;
-      }
-      .controls button {
-        flex: 1;
-        min-height: 38px;
-        padding: 0 4px;
-        font-size: 14px;
-        white-space: nowrap;
-      }
-      .primary {
-        background: var(--g);
-        border-color: var(--g);
-        color: white;
-      }
-      .tabs {
-        margin: 0 0 8px;
-      }
-      .tabs button {
-        min-height: 40px;
-        color: var(--muted);
-      }
-      .tabs .on {
-        border-color: #2e9961;
-        background: #e7f7ef;
-        color: var(--g);
-      }
-      .view {
-        display: none;
-      }
-      .view.on {
-        display: block;
-      }
-      .view.list.on {
-        display: grid;
-      }
-      .card,
-      .quick,
-      .group,
-      .note,
-      .tools {
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: white;
-        box-shadow: 0 6px 18px #23352e0f;
-      }
-      .card {
-        padding: 12px;
-      }
-      .head {
-        display: flex;
-        justify-content: space-between;
-        gap: 10px;
-        margin-bottom: 10px;
-      }
-      .head h2 {
-        margin: 2px 0 0;
-        font-size: 22px;
-      }
-      .done.on {
-        border-color: #2e9961;
-        background: #e7f7ef;
-        color: var(--g);
-      }
-      .block {
-        padding: 10px;
-        border-radius: 8px;
-        background: #fbfdf8;
-        border-left: 4px solid #2e9961;
-      }
-      .block + .block {
-        margin-top: 10px;
-      }
-      .support {
-        background: #f3f8ff;
-        border-left-color: var(--blue);
-      }
-      .hide-support .support {
-        display: none;
-      }
-      .bt {
-        margin-bottom: 7px;
-        color: var(--muted);
-        font-size: 13px;
-        font-weight: 900;
-      }
-      .block p {
-        margin: 0;
-        font-size: 16px;
-        font-weight: 680;
-        line-height: 1.55;
-        overflow-wrap: anywhere;
-      }
-      .support p {
-        font-size: 15px;
-      }
-      .quick {
-        display: grid;
-        grid-template-columns: 88px 1fr;
-        gap: 8px;
-        align-items: center;
-        margin-top: 8px;
-        padding: 10px;
-        background: #fffdf0;
-      }
-      .qv {
-        display: block;
-        color: #7b5412;
-        font-size: 28px;
-        font-weight: 950;
-      }
-      .list {
-        gap: 8px;
-      }
-      .group {
-        overflow: hidden;
-      }
-      .gt {
-        display: flex;
-        justify-content: space-between;
-        gap: 8px;
-        padding: 10px 11px;
-        background: #eff8f2;
-        color: var(--g);
-        font-weight: 950;
-      }
-      .row {
-        display: grid;
-        grid-template-columns: 68px 1fr 24px;
-        gap: 8px;
-        align-items: center;
-        width: 100%;
-        min-height: 48px;
-        padding: 7px 9px;
-        border: 0;
-        border-top: 1px solid #e8f1eb;
-        border-radius: 0;
-        text-align: left;
-      }
-      .row.on {
-        background: #fff9dc;
-      }
-      .time {
-        color: var(--g);
-        font-weight: 950;
-      }
-      .copy {
-        font-size: 14px;
-        line-height: 1.35;
-        overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-      }
-      .check {
-        color: #2e9961;
-        text-align: center;
-      }
-      .note {
-        padding: 10px;
-      }
-      .note h2 {
-        margin: 0 0 8px;
-        font-size: 16px;
-      }
-      .note li {
-        margin-bottom: 7px;
-        line-height: 1.55;
-      }
-      .tools {
-        display: grid;
-        gap: 8px;
-        padding: 10px;
-      }
-      .danger {
-        background: #fff4f4;
-        color: #9f2e2e;
-      }
-      .bottom {
-        position: fixed;
-        left: 50%;
-        bottom: 0;
-        z-index: 10;
-        display: grid;
-        grid-template-columns: 1fr 72px 1fr;
-        gap: 8px;
-        width: min(100%, 390px);
-        padding: 8px 10px calc(8px + env(safe-area-inset-bottom));
-        border-top: 1px solid var(--line);
-        background: #f7fbf2f5;
-        transform: translateX(-50%);
-        backdrop-filter: blur(10px);
-      }
-      .pos {
-        display: grid;
-        place-items: center;
-        color: var(--muted);
-        font-weight: 900;
-      }
-      @media (max-width: 420px) {
-        .badge {
-          display: none;
-        }
-        .controls {
-          grid-template-columns: 1fr 1fr;
-        }
-        .quick {
-          grid-template-columns: 1fr;
-        }
-      }
-    
+:root {
+  --bg: #f7fbf2;
+  --ink: #1d2a25;
+  --muted: #64736c;
+  --line: #d7e7dc;
+  --g: #176c45;
+  --blue: #347fc4;
+}
+* {
+  box-sizing: border-box;
+}
+html {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif;
+}
+body {
+  margin: 0;
+  background: linear-gradient(#fbfff6, #eef7fb);
+  min-height: 100vh;
+}
+button {
+  min-height: 44px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: white;
+  color: var(--ink);
+  font: inherit;
+  font-weight: 800;
+  touch-action: manipulation;
+}
+button:active {
+  transform: translateY(1px);
+}
+.app {
+  width: min(100%, 390px);
+  margin: auto;
+  min-height: 100vh;
+  padding-bottom: 78px;
+}
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: calc(10px + env(safe-area-inset-top)) 12px 8px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.logo {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 2px solid #9a6a3a;
+  border-radius: 6px;
+  background: #d9a86e;
+  color: #51351e;
+  font-weight: 950;
+}
+.k {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+h1 {
+  margin: 2px 0 0;
+  font-size: 16px;
+}
+.badge {
+  padding: 7px 9px;
+  border: 1px solid #cfe2d5;
+  border-radius: 99px;
+  background: #fff9de;
+  color: #6d5317;
+  font-size: 12px;
+  font-weight: 900;
+}
+main {
+  padding: 0 10px;
+}
+.timer {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  margin-bottom: 8px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fffffff2;
+  box-shadow: 0 10px 24px #23352e1a;
+  backdrop-filter: blur(10px);
+}
+.top {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+.clock {
+  display: block;
+  font-size: 32px;
+  font-weight: 950;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.sec {
+  max-width: 45%;
+  align-self: start;
+  padding: 8px;
+  border-radius: 8px;
+  background: #f0f7f4;
+  color: var(--g);
+  font-size: 13px;
+  font-weight: 900;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.bar {
+  height: 10px;
+  margin: 12px 0 8px;
+  border-radius: 99px;
+  background: #e6eee9;
+  overflow: hidden;
+}
+.bar i {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #2e9961, #ffe27a, #347fc4);
+}
+.meta {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 800;
+}
+.controls {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+.controls button {
+  flex: 1;
+  min-height: 38px;
+  font-size: 14px;
+}
+.primary {
+  background: var(--g);
+  border-color: var(--g);
+  color: white;
+}
+.danger {
+  background: #fff4f4;
+  color: #9f2e2e;
+}
+.view {
+  display: none;
+}
+.view.on {
+  display: block;
+}
+.view.list.on {
+  display: grid;
+}
+.card,
+.group {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: white;
+  box-shadow: 0 6px 18px #23352e0f;
+}
+.card {
+  padding: 12px;
+}
+.head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.head h2 {
+  margin: 2px 0 0;
+  font-size: 22px;
+}
+.head-right {
+  display: grid;
+  gap: 6px;
+  justify-items: end;
+}
+.quiz10 {
+  min-height: 34px;
+  min-width: 72px;
+  padding: 0 10px;
+  border-color: #dbb85b;
+  background: #fff7de;
+  color: #7b5412;
+}
+.line-remain {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 900;
+}
+.block {
+  padding: 10px;
+  border-radius: 8px;
+  background: #fbfdf8;
+  border-left: 4px solid #2e9961;
+}
+.block + .block {
+  margin-top: 10px;
+}
+.support {
+  background: #f3f8ff;
+  border-left-color: var(--blue);
+}
+.memo {
+  background: #fffdf0;
+  border-left-color: #dbb85b;
+}
+.bt {
+  margin-bottom: 7px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 900;
+}
+.block p {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 680;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+.support p,
+.memo p {
+  font-size: 15px;
+}
+.list {
+  gap: 8px;
+}
+.group {
+  overflow: hidden;
+}
+.gt {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 11px;
+  background: #eff8f2;
+  color: var(--g);
+  font-weight: 950;
+}
+.row {
+  display: grid;
+  grid-template-columns: 68px 1fr;
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+  min-height: 48px;
+  padding: 7px 9px;
+  border: 0;
+  border-top: 1px solid #e8f1eb;
+  border-radius: 0;
+  text-align: left;
+}
+.row.on {
+  background: #fff9dc;
+}
+.time {
+  color: var(--g);
+  font-weight: 950;
+}
+.copy {
+  font-size: 14px;
+  line-height: 1.35;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.bottom {
+  position: fixed;
+  left: 50%;
+  bottom: 0;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: 1fr 84px 1fr;
+  gap: 8px;
+  width: min(100%, 390px);
+  padding: 8px 10px calc(8px + env(safe-area-inset-bottom));
+  border-top: 1px solid var(--line);
+  background: #f7fbf2f5;
+  transform: translateX(-50%);
+  backdrop-filter: blur(10px);
+}
+.pos {
+  display: grid;
+  place-items: center;
+  min-height: 44px;
+  color: var(--muted);
+  font-weight: 900;
+}
+@media (max-width: 420px) {
+  .badge {
+    display: none;
+  }
+}

--- a/bear.html
+++ b/bear.html
@@ -34,16 +34,11 @@
           <div class="bar"><i id="bar"></i></div>
           <div id="meta" class="meta"></div>
           <div class="controls">
-            <button id="start" class="primary">▶ 開始</button
-            ><button id="now">◎ 現在</button><button id="minus">−1分</button
-            ><button id="plus">＋1分</button>
+            <button id="start" class="primary">▶ スタート</button>
+            <button id="reset" class="danger">リセット</button>
           </div>
         </section>
-        <nav class="tabs">
-          <button class="on" data-v="run">台本</button
-          ><button data-v="tl">全体</button><button data-v="notes">メモ</button
-          ><button data-v="tools">道具</button>
-        </nav>
+
         <section id="run" class="view on">
           <article class="card">
             <div class="head">
@@ -51,7 +46,10 @@
                 <p id="curSec" class="k">開始・注意事項</p>
                 <h2 id="curLabel">0:00</h2>
               </div>
-              <button id="done" class="done">未完了</button>
+              <div class="head-right">
+                <button id="q10" class="quiz10" hidden>🕰️10</button>
+                <div id="lineRemain" class="line-remain">残り 0:00</div>
+              </div>
             </div>
             <div class="block">
               <div class="bt">司会</div>
@@ -61,29 +59,18 @@
               <div class="bt">サポート係</div>
               <p id="support"></p>
             </div>
+            <div id="memoBox" class="block memo" hidden>
+              <div class="bt">メモ</div>
+              <p id="memo"></p>
+            </div>
           </article>
-          <section class="quick">
-            <div>
-              <p class="k">クイズ用</p>
-              <output id="quick" class="qv">--</output>
-            </div>
-            <div class="qa">
-              <button id="q10">10秒</button><button id="q30">30秒</button
-              ><button id="qstop">⏸ 停止</button>
-            </div>
-          </section>
         </section>
+
         <section id="tl" class="view list"></section>
-        <section id="notes" class="view list"></section>
-        <section id="tools" class="view tools">
-          <button id="supportBtn">サポート表示 ON</button
-          ><button id="wake">画面ON</button
-          ><button id="reset" class="danger">リセット</button>
-        </section>
       </main>
       <footer class="bottom">
         <button id="prev">← 戻る</button>
-        <div id="pos" class="pos">1 / 39</div>
+        <button id="pos" class="pos" type="button">1 / 39</button>
         <button id="next">次へ →</button>
       </footer>
     </div>

--- a/bear.js
+++ b/bear.js
@@ -356,58 +356,51 @@
           ],
         ],
         L = [
-          [`elapsed`, `経過`],
-          [`host`, `司会`],
-          [`support`, `サポート係`],
-          [`quiz`, `クイズ用`],
           [`rem`, `残り`],
           [`over`, `超過`],
           [`next`, `次`],
           [`end`, `終了`],
-          [`stop`, `⏸ 停止`],
-          [`done`, `完了`],
-          [`undone`, `未完了`],
-          [`supportOn`, `サポート表示 ON`],
-          [`supportOff`, `サポート表示 OFF`],
-          [`wake`, `画面ON`],
-          [`wakeActive`, `画面ON中`],
-          [`unsupported`, `非対応`],
-          [`unavailable`, `不可`],
-          [`reset`, `リセット`],
-          [`resetConfirm`, `タイマーと完了チェックをリセットしますか？`],
-        ];
+          [`stop`, `■ ストップ`],
+          [`start`, `▶ スタート`],
+          [`resetConfirm`, `タイマーをリセットしますか？`],
+        ],
+        MEMO_BY_SECTION = {
+          opening: [`スタンプカード配布と安全アナウンスを忘れずに。`],
+          quiz: [
+            `クイズは7分が目安。押したら区切って先生コメントへ。`,
+            `移動時は走らないよう声かけする。`,
+          ],
+          comments: [`先生コメントは短くテンポよく進行する。`],
+          chat: [`くじ引き・お菓子配布の動線を優先して確保する。`],
+          game: [`新聞紙じゃんけんは安全第一。無理な体勢は止める。`],
+          closing: [`ネームカードとゴミの回収漏れを最終確認する。`],
+        };
       const LT = Object.fromEntries(L),
         $ = (q) => document.querySelector(q),
         $$ = (q) => document.querySelectorAll(q),
         E = {
-          body: document.body,
           clock: $("#clock"),
           bar: $("#bar"),
           sec: $("#sec"),
           meta: $("#meta"),
           start: $("#start"),
-          now: $("#now"),
-          minus: $("#minus"),
-          plus: $("#plus"),
+          reset: $("#reset"),
           curSec: $("#curSec"),
           curLabel: $("#curLabel"),
+          lineRemain: $("#lineRemain"),
           host: $("#host"),
           support: $("#support"),
           supportBox: $("#supportBox"),
-          done: $("#done"),
-          quick: $("#quick"),
+          memo: $("#memo"),
+          memoBox: $("#memoBox"),
+          q10: $("#q10"),
+          run: $("#run"),
           tl: $("#tl"),
-          notes: $("#notes"),
-          tools: $("#tools"),
-          supportBtn: $("#supportBtn"),
-          wake: $("#wake"),
-          reset: $("#reset"),
           prev: $("#prev"),
           next: $("#next"),
           pos: $("#pos"),
         };
       let st = load(),
-        wake = null,
         qt = null,
         qr = 0;
       function load() {
@@ -417,15 +410,10 @@
           base: 0,
           i: 0,
           follow: 1,
-          done: {},
           view: "run",
-          support: 1,
         };
         try {
-          return Object.assign(
-            d,
-            JSON.parse(localStorage.getItem(KEY) || "{}"),
-          );
+          return Object.assign(d, JSON.parse(localStorage.getItem(KEY) || "{}"));
         } catch {
           return d;
         }
@@ -485,11 +473,6 @@
       function fmt(s) {
         return esc(s).split("|").join("<br>");
       }
-      function show(v) {
-        st.view = v;
-        save();
-        render();
-      }
       function render() {
         let t = elapsed();
         if (t >= TOTAL && st.run) {
@@ -503,8 +486,8 @@
           s = secById(d[1]),
           cs = secByTime(t),
           nx = DATA[i + 1],
-          remain = cs[4] - t;
-        E.body.classList.toggle("hide-support", !st.support);
+          remain = cs[4] - t,
+          lineRemain = (nx ? nx[3] : cs[4]) - t;
         E.clock.value = clock(t);
         E.bar.style.width = Math.min(100, (t / TOTAL) * 100) + "%";
         E.sec.textContent = cs[1];
@@ -512,9 +495,7 @@
           "<span>" +
           cs[2] +
           " / " +
-          (remain >= 0
-            ? LT.rem + " " + mm(remain)
-            : LT.over + " " + mm(-remain)) +
+          (remain >= 0 ? LT.rem + " " + mm(remain) : LT.over + " " + mm(-remain)) +
           "</span><span>" +
           (nx
             ? LT.next +
@@ -524,27 +505,31 @@
               (nx[3] >= t ? mm(nx[3] - t) : LT.over + " " + mm(t - nx[3]))
             : LT.end) +
           "</span>";
-        E.start.textContent = st.run ? LT.stop : "▶ 開始";
+        E.start.textContent = st.run ? LT.stop : LT.start;
         E.curSec.textContent = s[1];
         E.curLabel.textContent = d[2];
         E.host.innerHTML = fmt(d[4]);
         E.support.innerHTML = d[5] ? fmt(d[5]) : " ";
         E.supportBox.hidden = !d[5];
-        E.done.textContent = st.done[d[0]] ? LT.done : LT.undone;
-        E.done.classList.toggle("on", !!st.done[d[0]]);
+        let memo = MEMO_BY_SECTION[d[1]] || [];
+        E.memoBox.hidden = !memo.length;
+        E.memo.innerHTML = memo.map((m) => "・" + esc(m)).join("<br>");
+        E.lineRemain.textContent =
+          (lineRemain >= 0 ? LT.rem : LT.over) + " " + mm(Math.abs(lineRemain));
+
+        E.q10.hidden = d[1] !== "quiz";
+        E.q10.textContent = qr > 0 ? "🕰️" + qr : "🕰️10";
+
         E.pos.textContent = i + 1 + " / " + DATA.length;
         E.prev.disabled = i === 0;
         E.next.disabled = i === DATA.length - 1;
-        E.supportBtn.textContent = st.support ? LT.supportOn : LT.supportOff;
-        $$(".tabs button").forEach((b) =>
-          b.classList.toggle("on", b.dataset.v === st.view),
-        );
-        $$(".view").forEach((v) => v.classList.toggle("on", v.id === st.view));
+
+        E.run.classList.toggle("on", st.view === "run");
+        E.tl.classList.toggle("on", st.view === "tl");
+
         $$(".row").forEach((r) => {
-          let n = +r.dataset.i,
-            dd = DATA[n];
+          let n = +r.dataset.i;
           r.classList.toggle("on", n === i);
-          r.querySelector(".check").textContent = st.done[dd[0]] ? "✓" : "";
         });
       }
       function build() {
@@ -565,26 +550,14 @@
                   esc(x[0][2]) +
                   "</span><span class=copy>" +
                   esc(x[0][4].split("|")[0]) +
-                  "</span><span class=check></span></button>",
+                  "</span></button>",
               )
               .join("") +
             "</section>",
         ).join("");
-        E.notes.innerHTML = NOTES.map(
-          (n) =>
-            "<article class=note><h2>" +
-            esc(n[0]) +
-            "</h2><ul>" +
-            n[1].map((x) => "<li>" + esc(x) + "</li>").join("") +
-            "</ul></article>",
-        ).join("");
       }
       function move(n) {
-        st.i = clamp(
-          (st.follow ? idx(elapsed()) : st.i) + n,
-          0,
-          DATA.length - 1,
-        );
+        st.i = clamp((st.follow ? idx(elapsed()) : st.i) + n, 0, DATA.length - 1);
         st.follow = 0;
         save();
         render();
@@ -592,15 +565,16 @@
       function quick(n) {
         clearInterval(qt);
         qr = n;
-        E.quick.value = qr;
+        render();
         qt = setInterval(() => {
           qr--;
-          E.quick.value = qr > 0 ? qr : 0;
           if (qr <= 0) {
             clearInterval(qt);
             qt = null;
+            qr = 0;
             if (navigator.vibrate) navigator.vibrate([120, 60, 120]);
           }
+          render();
         }, 1000);
       }
       E.start.onclick = () => {
@@ -610,74 +584,24 @@
         save();
         render();
       };
-      E.now.onclick = () => {
-        st.follow = 1;
-        st.i = idx(elapsed());
-        save();
-        render();
-      };
-      E.minus.onclick = () => {
-        st.t = clamp(elapsed() - 60, 0, TOTAL);
-        st.base = Date.now();
-        save();
-        render();
-      };
-      E.plus.onclick = () => {
-        st.t = clamp(elapsed() + 60, 0, TOTAL);
-        st.base = Date.now();
-        save();
-        render();
-      };
-      E.prev.onclick = () => move(-1);
-      E.next.onclick = () => move(1);
-      E.done.onclick = () => {
-        let id = DATA[st.i][0];
-        st.done[id] = !st.done[id];
-        save();
-        render();
-      };
-      $("#q10").onclick = () => quick(10);
-      $("#q30").onclick = () => quick(30);
-      $("#qstop").onclick = () => {
-        clearInterval(qt);
-        qt = null;
-        E.quick.value = "--";
-      };
-      E.supportBtn.onclick = () => {
-        st.support = !st.support;
-        save();
-        render();
-      };
       E.reset.onclick = () => {
         if (confirm(LT.resetConfirm)) {
+          clearInterval(qt);
+          qt = null;
+          qr = 0;
           localStorage.removeItem(KEY);
           st = load();
           render();
         }
       };
-      E.wake.onclick = async () => {
-        if (wake) {
-          await wake.release();
-          wake = null;
-          E.wake.textContent = LT.wake;
-          return;
-        }
-        if (!navigator.wakeLock) {
-          E.wake.textContent = LT.unsupported;
-          return;
-        }
-        try {
-          wake = await navigator.wakeLock.request("screen");
-          E.wake.textContent = LT.wakeActive;
-          wake.addEventListener("release", () => {
-            wake = null;
-            E.wake.textContent = LT.wake;
-          });
-        } catch {
-          E.wake.textContent = LT.unavailable;
-        }
+      E.prev.onclick = () => move(-1);
+      E.next.onclick = () => move(1);
+      E.pos.onclick = () => {
+        st.view = st.view === "run" ? "tl" : "run";
+        save();
+        render();
       };
-      $$(".tabs button").forEach((b) => (b.onclick = () => show(b.dataset.v)));
+      E.q10.onclick = () => quick(10);
       E.tl.onclick = (e) => {
         let b = e.target.closest(".row");
         if (b) {
@@ -697,4 +621,3 @@
         }
       }, 500);
       render();
-    


### PR DESCRIPTION
### Motivation
- タイマーの操作を分かりやすくするため、ボタンをスタート/ストップとリセットのみに整理し、リセット時に確認ダイアログを必須化しました。 
- 台本行ごとの「未完了/完了」操作や複数タブが混在して分かりにくかったため、表示を実行画面中心に一本化し残り時間表示へ置換しました。 
- メモや道具などの別タブを廃止して、セクションに応じたメモをサポート係の下に表示する運用に変更しました。 
- クイズ用タイマーは10秒のみをクイズのセクション中だけ表示するシンプルなUXに限定しました。 

### Description
- `bear.html`: コントロールを `Start` / `Reset` の2ボタンへ変更しタブ群を削除、台本カード右上に `🕰️10` ボタンと行残り時間表示を追加し、サポート下にメモ領域 (`#memoBox`) を追加しました。 
- `bear.js`: 完了チェックや複数のクイックタイマーを削除し、`MEMO_BY_SECTION` によるセクション別メモ表示を追加、`lineRemain` を計算して行ごとの残り/超過時間を表示するように変更、`q10` はクイズセクション時のみ表示されるよう制御し、`pos` をタップで `run` <-> `tl` の切替に変更、`reset` は確認ダイアログとタイマー/クイックのクリア処理を実装しました。 
- `bear.css`: タブ/旧ツール用スタイルを整理・削除し、ヘッダー右側の `head-right`／`quiz10`／`line-remain`／`memo` ブロックのスタイルを追加して新UIに合わせて再構成しました。 

### Testing
- `node --check bear.js` を実行して構文チェックは成功しました。 
- 変更ファイルをステージしてコミットを作成しコミット処理は正常に完了しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee02687bf4832581b816b5fd6d1ae4)