### PR TITLE
Make timer stop act as pause and record press time

### DIFF
--- a/bear.js
+++ b/bear.js
@@ -408,6 +408,7 @@
           t: 0,
           run: 0,
           base: 0,
+          pausedAt: 0,
           i: 0,
           follow: 1,
           view: "run",
@@ -578,9 +579,16 @@
         }, 1000);
       }
       E.start.onclick = () => {
-        st.run = !st.run;
-        st.base = Date.now();
-        st.t = elapsed();
+        let pressedAt = Date.now();
+        if (st.run) {
+          st.t = clamp(st.t + Math.floor((pressedAt - st.base) / 1000), 0, TOTAL);
+          st.run = 0;
+          st.base = 0;
+          st.pausedAt = pressedAt;
+        } else {
+          st.base = pressedAt;
+          st.run = 1;
+        }
         save();
         render();
       };


### PR DESCRIPTION
### Motivation

- The timer stop action should behave as a pause rather than resetting or losing progress, by recording the time the button was pressed and using it to compute elapsed time.

### Description

- Added a `pausedAt` field to the persisted state in `load()` to store the pause timestamp (`pausedAt`).
- Reworked the `E.start.onclick` toggle so it captures `pressedAt = Date.now()` and, when stopping, increments `st.t` by `Math.floor((pressedAt - st.base) / 1000)`, clears `st.base`, sets `st.run = 0`, and saves `st.pausedAt`.
- When starting from a paused state the code now sets `st.base = pressedAt` and `st.run = 1` so `elapsed()` continues from the paused total.
- Kept the existing `elapsed()` and `save()` behavior (which persists `t` and sets `base` when running) while ensuring the stop action correctly finalizes accumulated seconds.

### Testing

- Ran a syntax check with `node --check bear.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee061015b083258215388d4d6e1bfd)