### PR TITLE
11:30基準の進行表示へ切替（タイマー操作削除）

### DIFF
--- a/bear.css
+++ b/bear.css
@@ -145,7 +145,7 @@ main {
   line-height: 1;
 }
 .sec {
-  max-width: 45%;
+  max-width: 58%;
   align-self: start;
   padding: 8px;
   border-radius: 8px;
@@ -153,9 +153,7 @@ main {
   color: var(--g);
   font-size: 13px;
   font-weight: 900;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  line-height: 1.4;
 }
 .bar {
   height: 10px;
@@ -176,25 +174,6 @@ main {
   color: var(--muted);
   font-size: 13px;
   font-weight: 800;
-}
-.controls {
-  display: flex;
-  gap: 6px;
-  margin-top: 10px;
-}
-.controls button {
-  flex: 1;
-  min-height: 38px;
-  font-size: 14px;
-}
-.primary {
-  background: var(--g);
-  border-color: var(--g);
-  color: white;
-}
-.danger {
-  background: #fff4f4;
-  color: #9f2e2e;
 }
 .view {
   display: none;

--- a/bear.html
+++ b/bear.html
@@ -7,7 +7,7 @@
       content="width=device-width,initial-scale=1,viewport-fit=cover"
     />
     <meta name="theme-color" content="#f7fbf2" />
-    <title>Bearクラス 進行タイマー</title>
+    <title>Bearクラス 進行ガイド</title>
     <link rel="stylesheet" href="./bear.css" />
   </head>
   <body>
@@ -19,26 +19,22 @@
           </div>
           <div>
             <p class="k">Bear Class</p>
-            <h1>懇親会 進行タイマー</h1>
+            <h1>懇親会 進行ガイド</h1>
           </div>
         </div>
-        <div class="badge">v10 PDF</div>
+        <div class="badge">v11 11:30基準</div>
       </header>
       <main>
         <section class="timer">
           <div class="top">
             <div>
-              <p class="k">経過</p>
+              <p class="k">現在時刻</p>
               <output id="clock" class="clock">0:00:00</output>
             </div>
             <div id="sec" class="sec">開始・注意事項</div>
           </div>
           <div class="bar"><i id="bar"></i></div>
           <div id="meta" class="meta"></div>
-          <div class="controls">
-            <button id="start" class="primary">▶ スタート</button>
-            <button id="reset" class="danger">リセット</button>
-          </div>
         </section>
 
         <section id="run" class="view on">

--- a/bear.js
+++ b/bear.js
@@ -1,5 +1,7 @@
       const TOTAL = 3600,
-        KEY = "bear-shinkou-timer-v10",
+        KEY = "bear-shinkou-timer-v11",
+        BASE_HOUR = 11,
+        BASE_MIN = 30,
         SEC = [
           [`opening`, `開始・注意事項`, `0:00-0:03`, 0, 180],
           [`quiz`, `先生クイズ（7分）`, `0:03-0:10`, 180, 600],
@@ -358,11 +360,11 @@
         L = [
           [`rem`, `残り`],
           [`over`, `超過`],
+          [`delay`, `遅れ`],
+          [`ahead`, `進み`],
+          [`onTime`, `オンスケ`],
           [`next`, `次`],
           [`end`, `終了`],
-          [`stop`, `■ ストップ`],
-          [`start`, `▶ スタート`],
-          [`resetConfirm`, `タイマーをリセットしますか？`],
         ],
         MEMO_BY_SECTION = {
           opening: [`スタンプカード配布と安全アナウンスを忘れずに。`],
@@ -388,8 +390,6 @@
           bar: $("#bar"),
           sec: $("#sec"),
           meta: $("#meta"),
-          start: $("#start"),
-          reset: $("#reset"),
           curSec: $("#curSec"),
           curLabel: $("#curLabel"),
           lineRemain: $("#lineRemain"),
@@ -409,15 +409,7 @@
         qt = null,
         qr = 0;
       function load() {
-        let d = {
-          t: 0,
-          run: 0,
-          base: 0,
-          pausedAt: 0,
-          i: 0,
-          follow: 1,
-          view: "run",
-        };
+        let d = { i: 0, follow: 1, view: "run" };
         try {
           return Object.assign(d, JSON.parse(localStorage.getItem(KEY) || "{}"));
         } catch {
@@ -425,23 +417,13 @@
         }
       }
       function save() {
-        localStorage.setItem(
-          KEY,
-          JSON.stringify(
-            Object.assign({}, st, {
-              t: elapsed(),
-              base: st.run ? Date.now() : 0,
-            }),
-          ),
-        );
+        localStorage.setItem(KEY, JSON.stringify(st));
       }
       function clamp(v, min, max) {
         return Math.min(max, Math.max(min, Number.isFinite(v) ? v : min));
       }
       function elapsed() {
-        return st.run
-          ? clamp(st.t + Math.floor((Date.now() - st.base) / 1000), 0, TOTAL)
-          : clamp(st.t, 0, TOTAL);
+        return Math.floor((Date.now() - baseTime().getTime()) / 1000);
       }
       function idx(t) {
         let x = 0;
@@ -470,6 +452,32 @@
         t = Math.max(0, Math.floor(t));
         return Math.floor(t / 60) + ":" + pad(t % 60);
       }
+      function hm(t) {
+        let x = new Date(baseTime().getTime() + Math.floor(t) * 1000);
+        return pad(x.getHours()) + ":" + pad(x.getMinutes());
+      }
+      function hms(d) {
+        return pad(d.getHours()) + ":" + pad(d.getMinutes()) + ":" + pad(d.getSeconds());
+      }
+      function baseTime() {
+        let now = new Date();
+        return new Date(
+          now.getFullYear(),
+          now.getMonth(),
+          now.getDate(),
+          BASE_HOUR,
+          BASE_MIN,
+          0,
+          0,
+        );
+      }
+      function secRange(s) {
+        return hm(s[3]) + "-" + hm(s[4]);
+      }
+      function status(delta) {
+        if (Math.abs(delta) <= 5) return LT.onTime;
+        return delta > 0 ? LT.delay + " +" + mm(delta) : LT.ahead + " -" + mm(-delta);
+      }
       function esc(s) {
         return String(s)
           .replaceAll("&", "&amp;")
@@ -480,40 +488,32 @@
         return esc(s).split("|").join("<br>");
       }
       function render() {
-        let t = elapsed();
-        if (t >= TOTAL && st.run) {
-          st.t = TOTAL;
-          st.run = 0;
-          st.base = 0;
-        }
-        let i = st.follow ? idx(t) : clamp(st.i, 0, DATA.length - 1);
+        let now = new Date(),
+          tRaw = elapsed(),
+          t = clamp(tRaw, 0, TOTAL),
+          i = st.follow ? idx(t) : clamp(st.i, 0, DATA.length - 1);
         st.i = i;
         let d = DATA[i],
           s = secById(d[1]),
           cs = secByTime(t),
           nx = DATA[i + 1],
           remain = cs[4] - t,
-          lineRemain = (nx ? nx[3] : cs[4]) - t;
-        E.clock.value = clock(t);
+          lineRemain = (nx ? nx[3] : cs[4]) - t,
+          delta = tRaw - d[3];
+        E.clock.value = hms(now);
         E.bar.style.width = Math.min(100, (t / TOTAL) * 100) + "%";
-        E.sec.textContent = cs[1];
+        E.sec.textContent = cs[1] + " (" + secRange(cs) + ")";
         E.meta.innerHTML =
-          "<span>" +
-          cs[2] +
+          "<span>基準 " +
+          hm(0) +
           " / " +
-          (remain >= 0 ? LT.rem + " " + mm(remain) : LT.over + " " + mm(-remain)) +
+          (tRaw >= 0 ? "経過 " + clock(t) : "開始まで " + mm(-tRaw)) +
           "</span><span>" +
-          (nx
-            ? LT.next +
-              " " +
-              nx[2] +
-              " " +
-              (nx[3] >= t ? mm(nx[3] - t) : LT.over + " " + mm(t - nx[3]))
-            : LT.end) +
+          "進行 " +
+          status(delta) +
           "</span>";
-        E.start.textContent = st.run ? LT.stop : LT.start;
         E.curSec.textContent = s[1];
-        E.curLabel.textContent = d[2];
+        E.curLabel.textContent = hm(d[3]) + "（" + d[2] + "）";
         E.host.innerHTML = fmt(d[4]);
         E.support.innerHTML = d[5] ? fmt(d[5]) : " ";
         E.supportBox.hidden = !d[5];
@@ -544,7 +544,7 @@
             "<section class=group><div class=gt><span>" +
             esc(s[1]) +
             "</span><span>" +
-            s[2] +
+            secRange(s) +
             "</span></div>" +
             DATA.map((d, i) => [d, i])
               .filter((x) => x[0][1] === s[0])
@@ -553,7 +553,7 @@
                   "<button class=row data-i=" +
                   x[1] +
                   "><span class=time>" +
-                  esc(x[0][2]) +
+                  esc(hm(x[0][3])) +
                   "</span><span class=copy>" +
                   esc(x[0][4].split("|")[0]) +
                   "</span></button>",
@@ -583,30 +583,6 @@
           render();
         }, 1000);
       }
-      E.start.onclick = () => {
-        let pressedAt = Date.now();
-        if (st.run) {
-          st.t = clamp(st.t + Math.floor((pressedAt - st.base) / 1000), 0, TOTAL);
-          st.run = 0;
-          st.base = 0;
-          st.pausedAt = pressedAt;
-        } else {
-          st.base = pressedAt;
-          st.run = 1;
-        }
-        save();
-        render();
-      };
-      E.reset.onclick = () => {
-        if (confirm(LT.resetConfirm)) {
-          clearInterval(qt);
-          qt = null;
-          qr = 0;
-          localStorage.removeItem(KEY);
-          st = load();
-          render();
-        }
-      };
       E.prev.onclick = () => move(-1);
       E.next.onclick = () => move(1);
       E.pos.onclick = () => {
@@ -628,9 +604,6 @@
       };
       build();
       setInterval(() => {
-        if (st.run) {
-          render();
-          save();
-        }
+        render();
       }, 500);
       render();


### PR DESCRIPTION
### Motivation
- イベント開始が固定の「11:30」で決まっているため、手動スタート/リセットのタイマーを廃止してページ表示を11:30基準の絶対時刻に揃える目的です。 
- セクション見出し付近に開始/終了の絶対時刻（例: `11:30-11:33`）を表示し、現在時刻と進行の遅れ/進み/オンスケ状態を分かりやすく示す必要がありました。

### Description
- UIの文言を「進行タイマー」から「進行ガイド」に変更し、上部の開始/停止/リセットボタンと関連要素を画面から削除しました（`bear.html` / `bear.css`）。
- 表示基準を当日11:30に固定するために `BASE_HOUR`/`BASE_MIN` と `baseTime()` を導入し、経過秒を `Date.now() - baseTime()` で算出するようにしました（`bear.js`）。
- セクションやタイムラインの表示を11:30基準の絶対時刻へ変換する `hm()`/`hms()`/`secRange()` と進行判定の `status()` を追加して、上部メタに「現在時刻」と「進行（遅れ/進み/オンスケ）」を表示するようにしました（`bear.js`）。
- セクション時刻が収まるように `.sec` のスタイル幅と行間を調整し、不要になったコントロール用のスタイル群を削除しました（`bear.css`）。

### Testing
- `node --check bear.js` を実行して構文エラーがないことを確認済みで、チェックは成功しました. 
- コード内のタイマー関連要素削除を `rg` で検索して変更箇所を確認済みで、期待どおりボタン要素や関連キーが除去されていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee113150788325a807c4ae27e41f7c)