### PR TITLE
Add first-run usage overlay and disable auto-follow on startup

### DIFF
--- a/bear.css
+++ b/bear.css
@@ -321,6 +321,44 @@ main {
   color: var(--muted);
   font-weight: 900;
 }
+.guide {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+}
+.guide-backdrop {
+  position: absolute;
+  inset: 0;
+  background: #0f18159e;
+}
+.guide-card {
+  position: absolute;
+  left: 50%;
+  bottom: calc(96px + env(safe-area-inset-bottom));
+  width: min(92vw, 340px);
+  transform: translateX(-50%);
+  padding: 14px;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 12px 28px #0003;
+}
+.guide-card h2 {
+  margin: 4px 0 8px;
+  font-size: 20px;
+}
+.guide-card p {
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+.guide-target {
+  position: relative;
+  z-index: 31;
+  box-shadow: 0 0 0 3px #ffe27a;
+  border-radius: 8px;
+}
+body.guide-open {
+  overflow: hidden;
+}
 @media (max-width: 420px) {
   .badge {
     display: none;

--- a/bear.html
+++ b/bear.html
@@ -72,6 +72,15 @@
         <button id="next">次へ →</button>
       </footer>
     </div>
+    <div id="guide" class="guide" hidden>
+      <div id="guideBackdrop" class="guide-backdrop"></div>
+      <div id="guideCard" class="guide-card">
+        <p id="guideStep" class="k">使い方ガイド 1 / 4</p>
+        <h2 id="guideTitle">この画面の見かた</h2>
+        <p id="guideText"></p>
+        <button id="guideNext" type="button">次へ</button>
+      </div>
+    </div>
     <script src="./bear.js"></script>
   </body>
 </html>

--- a/bear.js
+++ b/bear.js
@@ -382,7 +382,17 @@
           game: [`新聞紙じゃんけんは安全第一。無理な体勢は止める。`],
           closing: [`ネームカードとゴミの回収漏れを最終確認する。`],
         };
-      const LT = Object.fromEntries(L),
+      const GUIDE_STEPS = [
+          { target: "#clock", title: "現在時刻", text: "画面左上に現在時刻を表示します。" },
+          {
+            target: "#pos",
+            title: "台本全体表示",
+            text: "中央ボタンで、進行カードと台本全体表示を切り替えできます。",
+          },
+          { target: "#prev", title: "前へ", text: "前の台本行に戻るときに使います。" },
+          { target: "#next", title: "次へ", text: "次の台本行に進むときに使います。" },
+        ],
+        LT = Object.fromEntries(L),
         $ = (q) => document.querySelector(q),
         $$ = (q) => document.querySelectorAll(q),
         E = {
@@ -404,14 +414,24 @@
           prev: $("#prev"),
           next: $("#next"),
           pos: $("#pos"),
+          guide: $("#guide"),
+          guideBackdrop: $("#guideBackdrop"),
+          guideStep: $("#guideStep"),
+          guideTitle: $("#guideTitle"),
+          guideText: $("#guideText"),
+          guideNext: $("#guideNext"),
         };
       let st = load(),
         qt = null,
-        qr = 0;
+        qr = 0,
+        guideStep = 0;
       function load() {
-        let d = { i: 0, follow: 1, view: "run" };
+        let d = { i: 0, follow: 0, view: "run", guideSeen: 0 };
         try {
-          return Object.assign(d, JSON.parse(localStorage.getItem(KEY) || "{}"));
+          let saved = Object.assign(d, JSON.parse(localStorage.getItem(KEY) || "{}"));
+          if (!("guideSeen" in saved)) saved.guideSeen = 0;
+          saved.follow = 0;
+          return saved;
         } catch {
           return d;
         }
@@ -568,6 +588,31 @@
         save();
         render();
       }
+      function showGuide() {
+        if (!GUIDE_STEPS.length) return;
+        let step = GUIDE_STEPS[guideStep],
+          target = step.target ? $(step.target) : null;
+        E.guideStep.textContent = "使い方ガイド " + (guideStep + 1) + " / " + GUIDE_STEPS.length;
+        E.guideTitle.textContent = step.title;
+        E.guideText.textContent = step.text;
+        E.guide.hidden = false;
+        document.body.classList.add("guide-open");
+        $$(".guide-target").forEach((el) => el.classList.remove("guide-target"));
+        if (target) target.classList.add("guide-target");
+        E.guideNext.textContent = guideStep === GUIDE_STEPS.length - 1 ? "はじめる" : "次へ";
+      }
+      function nextGuide() {
+        guideStep++;
+        if (guideStep >= GUIDE_STEPS.length) {
+          E.guide.hidden = true;
+          document.body.classList.remove("guide-open");
+          $$(".guide-target").forEach((el) => el.classList.remove("guide-target"));
+          st.guideSeen = 1;
+          save();
+          return;
+        }
+        showGuide();
+      }
       function quick(n) {
         clearInterval(qt);
         qr = n;
@@ -591,6 +636,8 @@
         render();
       };
       E.q10.onclick = () => quick(10);
+      E.guideNext.onclick = () => nextGuide();
+      E.guideBackdrop.onclick = () => nextGuide();
       E.tl.onclick = (e) => {
         let b = e.target.closest(".row");
         if (b) {
@@ -607,3 +654,4 @@
         render();
       }, 500);
       render();
+      if (!st.guideSeen) showGuide();


### PR DESCRIPTION
### Motivation
- 起動時に自動で現在時刻に合わせて台本位置へジャンプする挙動を無効化し、初回表示で不要な位置移動が起きないようにするため。 
- 初回利用者が操作を理解できるように、画面要素（現在時刻・台本全体表示・前へ・次へ）を案内するオンボードガイドを追加するため。

### Description
- `bear.js`：起動時の自動フォローをオフにするため `load()` のデフォルト `follow` を `0` に変更し、保存データ読込後も起動時は追従しないように調整した。 (`follow` を強制 `0` に設定)。
- `bear.js`：初回表示用のガイドロジックを追加し、`GUIDE_STEPS` 配列でステップを定義してガイドの表示・進行・完了の処理を実装し、完了状態を `localStorage` の `guideSeen` に保存するようにした。ガイド表示は未完了時のみ自動で開始する。 
- `bear.html`：ガイド用の DOM を追加し、オーバーレイとカード（`#guide`, `#guideBackdrop`, `#guideCard` など）を配置した。 
- `bear.css`：ガイドの背景オーバーレイ、カードスタイル、注目要素ハイライト（`.guide-target`）および表示中のスクロール抑制用スタイルを追加した。
- 変更対象ファイル：`bear.js`, `bear.html`, `bear.css`。

### Testing
- 静的構文チェックとして `node --check bear.js` を実行し、エラーなしで成功した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1323edc08325bc4fc7c5e811b727)