### PR TITLE
使い方ガイドをスキップ可能にし、ハイライトくり抜きオーバーレイを追加

### DIFF
--- a/bear.css
+++ b/bear.css
@@ -329,7 +329,22 @@ main {
 .guide-backdrop {
   position: absolute;
   inset: 0;
-  background: #0f18159e;
+  background: transparent;
+}
+.guide-hole {
+  position: fixed;
+  left: var(--hole-left, -9999px);
+  top: var(--hole-top, -9999px);
+  width: var(--hole-width, 0px);
+  height: var(--hole-height, 0px);
+  border-radius: 10px;
+  box-shadow: 0 0 0 9999px #0f18159e;
+  pointer-events: none;
+  transition:
+    left 0.18s ease,
+    top 0.18s ease,
+    width 0.18s ease,
+    height 0.18s ease;
 }
 .guide-card {
   position: absolute;
@@ -349,6 +364,16 @@ main {
 .guide-card p {
   margin: 0 0 12px;
   line-height: 1.5;
+}
+.guide-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.guide-card .ghost {
+  border-color: #d8e3dc;
+  color: var(--muted);
+  background: #fff;
 }
 .guide-target {
   position: relative;

--- a/bear.html
+++ b/bear.html
@@ -74,11 +74,15 @@
     </div>
     <div id="guide" class="guide" hidden>
       <div id="guideBackdrop" class="guide-backdrop"></div>
+      <div id="guideHole" class="guide-hole" aria-hidden="true"></div>
       <div id="guideCard" class="guide-card">
         <p id="guideStep" class="k">使い方ガイド 1 / 4</p>
         <h2 id="guideTitle">この画面の見かた</h2>
         <p id="guideText"></p>
-        <button id="guideNext" type="button">次へ</button>
+        <div class="guide-actions">
+          <button id="guideSkip" type="button" class="ghost">スキップ</button>
+          <button id="guideNext" type="button">次へ</button>
+        </div>
       </div>
     </div>
     <script src="./bear.js"></script>

--- a/bear.js
+++ b/bear.js
@@ -416,9 +416,11 @@
           pos: $("#pos"),
           guide: $("#guide"),
           guideBackdrop: $("#guideBackdrop"),
+          guideHole: $("#guideHole"),
           guideStep: $("#guideStep"),
           guideTitle: $("#guideTitle"),
           guideText: $("#guideText"),
+          guideSkip: $("#guideSkip"),
           guideNext: $("#guideNext"),
         };
       let st = load(),
@@ -599,16 +601,34 @@
         document.body.classList.add("guide-open");
         $$(".guide-target").forEach((el) => el.classList.remove("guide-target"));
         if (target) target.classList.add("guide-target");
+        drawGuideHole(target);
         E.guideNext.textContent = guideStep === GUIDE_STEPS.length - 1 ? "はじめる" : "次へ";
+      }
+      function drawGuideHole(target) {
+        if (!E.guideHole) return;
+        if (!target) {
+          E.guideHole.style.setProperty("--hole-left", "-9999px");
+          E.guideHole.style.setProperty("--hole-top", "-9999px");
+          return;
+        }
+        let r = target.getBoundingClientRect(),
+          pad = 8;
+        E.guideHole.style.setProperty("--hole-left", Math.max(0, r.left - pad) + "px");
+        E.guideHole.style.setProperty("--hole-top", Math.max(0, r.top - pad) + "px");
+        E.guideHole.style.setProperty("--hole-width", r.width + pad * 2 + "px");
+        E.guideHole.style.setProperty("--hole-height", r.height + pad * 2 + "px");
+      }
+      function closeGuide() {
+        E.guide.hidden = true;
+        document.body.classList.remove("guide-open");
+        $$(".guide-target").forEach((el) => el.classList.remove("guide-target"));
+        st.guideSeen = 1;
+        save();
       }
       function nextGuide() {
         guideStep++;
         if (guideStep >= GUIDE_STEPS.length) {
-          E.guide.hidden = true;
-          document.body.classList.remove("guide-open");
-          $$(".guide-target").forEach((el) => el.classList.remove("guide-target"));
-          st.guideSeen = 1;
-          save();
+          closeGuide();
           return;
         }
         showGuide();
@@ -637,6 +657,7 @@
       };
       E.q10.onclick = () => quick(10);
       E.guideNext.onclick = () => nextGuide();
+      E.guideSkip.onclick = () => closeGuide();
       E.guideBackdrop.onclick = () => nextGuide();
       E.tl.onclick = (e) => {
         let b = e.target.closest(".row");


### PR DESCRIPTION
### Motivation
- 初回表示される使い方ガイドをユーザーが任意で終了できるようにしてUXを改善するために、ガイドをスキップ可能にします。 
- ガイド中に注目対象だけを見せる「くり抜き」ハイライトを追加して、案内の視認性を高めます。

### Description
- `bear.html`: ガイド領域に`<div id="guideHole" class="guide-hole">`を追加し、ガイドの下部に`スキップ`ボタンを配置する`guide-actions`領域を追加しました。 
- `bear.css`: `.guide-hole`でターゲット周囲をくり抜く表現を実装し、`.guide-actions`と`.ghost`スタイルを追加、既存のバックドロップを透明に変更して`guide-hole`の影を使う方式に変更しました。 
- `bear.js`: `E.guideHole`/`E.guideSkip`を参照に追加し、ターゲット要素の座標から穴位置とサイズを更新する`drawGuideHole(target)`を実装しました。 
- `bear.js`: ガイド終了処理を`closeGuide()`に集約し、最後まで進めた場合と`スキップ`押下時で挙動を統一して`st.guideSeen`を保存するようにしました。 

### Testing
- `node --check bear.js` を実行して構文チェックが成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee14a051c4832599d994091ac79ecd)