### PR TITLE
Prevent double-tap zoom and add hash-based SPA routing to bear guide

### DIFF
--- a/bear.css
+++ b/bear.css
@@ -13,11 +13,13 @@ html {
   background: var(--bg);
   color: var(--ink);
   font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif;
+  touch-action: manipulation;
 }
 body {
   margin: 0;
   background: linear-gradient(#fbfff6, #eef7fb);
   min-height: 100vh;
+  touch-action: manipulation;
 }
 button {
   min-height: 44px;

--- a/bear.html
+++ b/bear.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width,initial-scale=1,viewport-fit=cover"
+      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no,viewport-fit=cover"
     />
     <meta name="theme-color" content="#f7fbf2" />
     <title>Bearクラス 進行ガイド</title>

--- a/bear.js
+++ b/bear.js
@@ -441,6 +441,26 @@
       function save() {
         localStorage.setItem(KEY, JSON.stringify(st));
       }
+      function parseRoute() {
+        let hash = (location.hash || "").replace(/^#/, ""),
+          [viewRaw, idxRaw] = hash.split("/");
+        let view = viewRaw === "tl" ? "tl" : "run",
+          i = Number.parseInt(idxRaw, 10);
+        return { view, i: Number.isFinite(i) ? clamp(i, 0, DATA.length - 1) : null };
+      }
+      function syncRoute(replace = false) {
+        let hash = "#" + st.view + "/" + st.i;
+        if (location.hash === hash) return;
+        if (replace) history.replaceState(null, "", hash);
+        else history.pushState(null, "", hash);
+      }
+      function applyRoute() {
+        let r = parseRoute();
+        st.view = r.view;
+        if (r.i !== null) st.i = r.i;
+        save();
+        render();
+      }
       function clamp(v, min, max) {
         return Math.min(max, Math.max(min, Number.isFinite(v) ? v : min));
       }
@@ -588,6 +608,7 @@
         st.i = clamp((st.follow ? idx(elapsed()) : st.i) + n, 0, DATA.length - 1);
         st.follow = 0;
         save();
+        syncRoute();
         render();
       }
       function showGuide() {
@@ -653,6 +674,7 @@
       E.pos.onclick = () => {
         st.view = st.view === "run" ? "tl" : "run";
         save();
+        syncRoute();
         render();
       };
       E.q10.onclick = () => quick(10);
@@ -666,11 +688,25 @@
           st.follow = 0;
           st.view = "run";
           save();
+          syncRoute();
           render();
           scrollTo({ top: 0, behavior: "smooth" });
         }
       };
+      let lastTouchEnd = 0;
+      document.addEventListener(
+        "touchend",
+        (e) => {
+          let now = Date.now();
+          if (now - lastTouchEnd < 300) e.preventDefault();
+          lastTouchEnd = now;
+        },
+        { passive: false },
+      );
+      window.addEventListener("hashchange", applyRoute);
       build();
+      applyRoute();
+      syncRoute(true);
       setInterval(() => {
         render();
       }, 500);


### PR DESCRIPTION
### Motivation
- モバイルでの誤タップによるダブルタップ拡大を抑制して操作性を改善するためにビューポートとタッチ挙動を制御しました。 
- ページ内の状態（一覧表示 / 本文表示 と現在行）を URL に反映してブラウザ履歴や共有で復元できるようにし、軽い SPA 風の遷移を実装しました。

### Description
- `bear.html` の `<meta name="viewport">` を `maximum-scale=1,user-scalable=no` に変更してブラウザによる拡大を抑制しました。 
- `bear.css` の `html` / `body` に `touch-action: manipulation` を追加してタッチジェスチャー由来の想定外ズームをさらに抑止しました。 
- `bear.js` にハッシュルーティングを追加し、`parseRoute` / `syncRoute` / `applyRoute` を実装して `#run/{index}` / `#tl/{index}` をサポートし、`prev`/`next`・モード切替・タイムライン行選択時に URL と状態を同期するようにしました。 
- `bear.js` に短時間連続タップ時の拡大を抑える `touchend` のガードを追加し、`hashchange` イベントでの復元と初回ハイドレーション（初期ルート適用）を行うようにしました。

### Testing
- `node --check bear.js` を実行して JavaScript の構文チェックを行い、エラーは報告されませんでした。 
- ブラウザ上の動作（実際のタッチ操作・ズーム抑止・ハッシュ遷移復元）はこの環境では自動化テストされておらず、手動での検証を推奨します。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee18276b508325a4d0d8c66ef2faf8)